### PR TITLE
udev: build by-path identifiers for ATA devices.

### DIFF
--- a/src/udev/udev-builtin-path_id.c
+++ b/src/udev/udev-builtin-path_id.c
@@ -310,6 +310,39 @@ out:
         return parent;
 }
 
+static struct udev_device *handle_scsi_ata(struct udev_device *parent, char **path) {
+        struct udev *udev  = udev_device_get_udev(parent);
+        struct udev_device *targetdev;
+        struct udev_device *target_parent;
+        struct udev_device *atadev;
+        const char *port_no;
+
+        assert(parent);
+        assert(path);
+
+        targetdev = udev_device_get_parent_with_subsystem_devtype(parent, "scsi", "scsi_host");
+        if (!targetdev)
+                return NULL;
+
+        target_parent = udev_device_get_parent(targetdev);
+        if (!target_parent)
+                return NULL;
+
+        atadev = udev_device_new_from_subsystem_sysname(udev, "ata_port", udev_device_get_sysname(target_parent));
+        if (!atadev)
+                return NULL;
+
+        port_no = udev_device_get_sysattr_value(atadev, "port_no");
+        if (!port_no) {
+               parent = NULL;
+               goto out;
+        }
+        path_prepend(path, "ata-%s", port_no);
+out:
+        udev_device_unref(atadev);
+        return parent;
+}
+
 static struct udev_device *handle_scsi_default(struct udev_device *parent, char **path) {
         struct udev_device *hostdev;
         int host, bus, target, lun;
@@ -510,7 +543,7 @@ static struct udev_device *handle_scsi(struct udev_device *parent, bool enable_n
         }
 
         if (strstr(name, "/ata") != NULL) {
-                parent = handle_ata(parent, path);
+                parent = handle_scsi_ata(parent, path);
                 goto out;
         }
 


### PR DESCRIPTION
/dev/disk/by-path

total 0
lrwxrwxrwx. 1 root root  9 Sep  4 10:02 pci-0000:00:1f.2-ata-2 -> ../../sr0
lrwxrwxrwx. 1 root root  9 Sep  4 10:02 pci-0000:00:1f.2-ata-3 -> ../../sdd
lrwxrwxrwx. 1 root root 10 Sep  4 10:02 pci-0000:00:1f.2-ata-3-part1 -> ../../sdd1
lrwxrwxrwx. 1 root root 10 Sep  4 10:02 pci-0000:00:1f.2-ata-3-part2 -> ../../sdd2
lrwxrwxrwx. 1 root root 10 Sep  4 10:02 pci-0000:00:1f.2-ata-3-part3 -> ../../sdd3
lrwxrwxrwx. 1 root root  9 Sep  4 10:02 pci-0000:03:00.0-ata-4 -> ../../sda
lrwxrwxrwx. 1 root root 10 Sep  4 10:02 pci-0000:03:00.0-ata-4-part1 -> ../../sda1
lrwxrwxrwx. 1 root root 10 Sep  4 10:02 pci-0000:03:00.0-ata-4-part2 -> ../../sda2
lrwxrwxrwx. 1 root root  9 Sep  4 10:02 pci-0000:08:00.0-ata-1 -> ../../sdc
lrwxrwxrwx. 1 root root 10 Sep  4 10:02 pci-0000:08:00.0-ata-1-part1 -> ../../sdc1
lrwxrwxrwx. 1 root root 10 Sep  4 10:02 pci-0000:08:00.0-ata-1-part2 -> ../../sdc2

Cherry-picked from: ba86822db70d9ffd02ad78cd02b237ff8c569c7a
Resolves: #950239
