### PR TITLE
tests: fix make check failure

### DIFF
--- a/src/test/test-install-root.c
+++ b/src/test/test-install-root.c
@@ -657,7 +657,7 @@ int main(int argc, char *argv[]) {
         test_indirect(root);
         test_preset_and_list(root);
 
-        assert_se(rm_rf_dangerous(root, false, true, false));
+        assert_se(rm_rf_dangerous(root, false, true, false) == 0);
 
         return 0;
 }


### PR DESCRIPTION
Don't call abort() on success. Actually rm_rf_dangerous() returns 0 if
all went well.

Related: #1159308
