### PR TITLE
systemctl: return diffrent error code if service exist or not

### DIFF
--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -4295,6 +4295,8 @@ static int show_one(
                  */
                 if (info.pid_file && access(info.pid_file, F_OK) == 0)
                         r = 1;
+                else if (streq_ptr(info.load_state, "not-found") && streq_ptr(info.active_state, "inactive"))
+                        r = 4;
                 else
                         r = 3;
         }


### PR DESCRIPTION
Before:
[sus@maximus bz-1256858]$ systemctl status rsyslog.service;echo $?
● rsyslog.service - System Logging Service
   Loaded: loaded (/usr/lib/systemd/system/rsyslog.service; enabled; vendor
preset: enabled)
  Drop-In: /etc/systemd/system/rsyslog.service.d
           └─50-CPUShares.conf
   Active: inactive (dead) since Mon 2016-05-30 11:54:25 IST; 2h 26min ago
     Docs: man:rsyslogd(8)
           http://www.rsyslog.com/doc/
  Process: 1159 ExecStart=/usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS (code=exited,
status=0/SUCCESS)
 Main PID: 1159 (code=exited, status=0/SUCCESS)

May 30 11:07:50 maximus systemd[1]: Starting System Logging Service...
May 30 11:07:50 maximus systemd[1]: Started System Logging Service.
May 30 11:54:25 maximus systemd[1]: Stopping System Logging Service...
May 30 11:54:25 maximus systemd[1]: Stopped System Logging Service.
3
[sus@maximus bz-1256858]$ systemctl status hello.service;echo $?
● hello.service
   Loaded: not-found (Reason: No such file or directory)
   Active: inactive (dead)
3

After:
$ ./systemctl status hello.service;echo $?
Failed to dump process list, ignoring: Access denied
● hello.service
   Loaded: not-found (Reason: No such file or directory)
   Active: inactive (dead)
4
[sus@maximus bz-1256858]$  ./systemctl status rsyslog.service;echo $?
Failed to dump process list, ignoring: Access denied
● rsyslog.service - System Logging Service
   Loaded: loaded (/usr/lib/systemd/system/rsyslog.service; enabled; vendor
preset: enabled)
  Drop-In: /etc/systemd/system/rsyslog.service.d
           └─50-CPUShares.conf
   Active: inactive (dead) since Mon 2016-05-30 11:54:25 IST; 2h 24min ago
     Docs: man:rsyslogd(8)
           http://www.rsyslog.com/doc/
  Process: 1159 ExecStart=/usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS (code=exited,
status=0/SUCCESS)
 Main PID: 1159 (code=exited, status=0/SUCCESS)

May 30 11:07:50 maximus systemd[1]: Starting System Logging Service...
May 30 11:07:50 maximus systemd[1]: Started System Logging Service.
May 30 11:54:25 maximus systemd[1]: Stopping System Logging Service...
May 30 11:54:25 maximus systemd[1]: Stopped System Logging Service.
3

Fixes: 1092

Cherry-picked from: 10b5871372c23f9572642f88816f7f3198cb91ac
Resolves: #1256858
