### PR TITLE
install: fix disable via unit file path

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -1910,10 +1910,12 @@ int unit_file_disable(
                 return r;
 
         STRV_FOREACH(i, files) {
-                if (!unit_name_is_valid(*i, UNIT_NAME_ANY))
-                        return -EINVAL;
 
-                r = install_info_add(&c, *i, NULL, NULL);
+                if (!is_path(*i))
+                        r = install_info_add(&c, *i, NULL, NULL);
+                else
+                        r = install_info_add(&c, NULL, *i, NULL);
+
                 if (r < 0)
                         return r;
         }


### PR DESCRIPTION
Drop the check for unit file name validity. install_info_add does that
anyway. Also pass NULL in place of name argument to install_info_add if
we are dealing with path to a unit file. install_info_add will figure
out a name from a path and it will correctly populate
UnitFileInstallInfo with both name and path. Then in
unit_file_search called from install_info_traverse we can take a
shortcut and attempt to load unit file directly.

Cherry-picked from: 4dfbf0b176ff0e8a352617eba5e79065ee477969
Resolves: #1348208
