### PR TITLE
udev/path_id: correct segmentation fault due to missing NULL check

### DIFF
--- a/src/udev/udev-builtin-path_id.c
+++ b/src/udev/udev-builtin-path_id.c
@@ -729,7 +729,7 @@ restart:
          * devices do not expose their buses and do not provide a unique
          * and predictable name that way.
          */
-        if (streq(udev_device_get_subsystem(dev), "block") && !supported_transport) {
+        if (streq_ptr(udev_device_get_subsystem(dev), "block") && !supported_transport) {
                 free(path);
                 path = NULL;
         }


### PR DESCRIPTION
Running "udevadm test-builtin path_id /sys/devices/platform/" results
in a segmentation fault.

The problem is that udev_device_get_subsystem(dev) might return NULL
in a streq() call.  Solve this problem by using streq_ptr() instead.

Cherry-picked from: 5181ab917d6407cb57043e98955f0de1614366ea
Resolves: #1365556
