### PR TITLE
logind: don't assert if the slice is missing

### DIFF
--- a/src/login/logind-session.c
+++ b/src/login/logind-session.c
@@ -507,7 +507,6 @@ static int session_start_scope(Session *s) {
 
         assert(s);
         assert(s->user);
-        assert(s->user->slice);
 
         if (!s->scope) {
                 _cleanup_bus_error_free_ sd_bus_error error = SD_BUS_ERROR_NULL;


### PR DESCRIPTION
After all, we don't actually really need the slice to work, it's just
nice to have it.

Cherry-picked from: 38599489e49e840291516488a3ef1b4a56198c58
Resolves: #1371437
