### PR TITLE
install: fix disable when /etc/systemd/system is a symlink

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -476,7 +476,7 @@ static int remove_marked_symlinks(
         if (set_size(remove_symlinks_to) <= 0)
                 return 0;
 
-        fd = open(config_path, O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+        fd = open(config_path, O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC);
         if (fd < 0)
                 return -errno;
 


### PR DESCRIPTION
Cherry-picked from: 67852d08e6a35d34b428e8be64efdb3f003f4697
Resolves: #1285996
