### PR TITLE
systemctl,pid1: do not warn about missing install info with "preset"

### DIFF
--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -1012,22 +1012,22 @@ kobject-uevent 1 systemd-udevd-kernel.socket systemd-udevd.service
           <term><command>preset <replaceable>NAME</replaceable>...</command></term>
 
           <listitem>
-            <para>Reset one or more unit files, as specified on the
-            command line, to the defaults configured in the preset
-            policy files. This has the same effect as
-            <command>disable</command> or <command>enable</command>,
-            depending how the unit is listed in the preset files.</para>
+            <para>Reset the enable/disable status one or more unit files, as specified on
+            the command line, to the defaults configured in the preset policy files. This
+            has the same effect as <command>disable</command> or
+            <command>enable</command>, depending how the unit is listed in the preset
+            files.</para>
 
-            <para>Use <option>--preset-mode=</option> to control
-            whether units shall be enabled and disabled, or only
-            enabled, or only disabled.</para>
+            <para>Use <option>--preset-mode=</option> to control whether units shall be
+            enabled and disabled, or only enabled, or only disabled.</para>
 
-            <para>For more information on the preset policy format,
-            see
+            <para>If the unit carries no install information, it will be silently ignored
+            by this command.</para>
+
+            <para>For more information on the preset policy format, see
             <citerefentry><refentrytitle>systemd.preset</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
-            For more information on the concept of presets, please
-            consult the <ulink
-            url="http://freedesktop.org/wiki/Software/systemd/Preset">Preset</ulink>
+            For more information on the concept of presets, please consult the
+            <ulink url="http://freedesktop.org/wiki/Software/systemd/Preset">Preset</ulink>
             document.</para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
When "preset" was executed for a unit without install info, we'd warn similarly
as for "enable" and "disable". But "preset" is usually called for all units,
because the preset files are provided by the distribution, and the units are under
control of individual programs, and it's reasonable to call "preset" for all units
rather then try to do it only for the ones that can be installed.
We also don't warn about missing info for "preset-all". Thus it seems reasonable
to silently ignore units w/o install info when presetting.

(In addition, when more than one unit was specified, we'd issue the warning
only if none of them had install info. But this is probably something to fix
for enable/disable too.)

Cherry-picked from: 39207373dd638e548019ddb49929f15795b8b404
Resolves: #1373950
