### PR TITLE
40-redhat.rules: don't hoplug memory on s390x

### DIFF
--- a/rules/40-redhat.rules
+++ b/rules/40-redhat.rules
@@ -4,7 +4,7 @@
 SUBSYSTEM=="cpu", ACTION=="add", TEST=="online", ATTR{online}=="0", ATTR{online}="1"
 
 # Memory hotadd request
-SUBSYSTEM=="memory", ACTION=="add", ATTR{state}=="offline", ATTR{state}="online"
+SUBSYSTEM=="memory", ACTION=="add", PROGRAM="/usr/bin/systemd-detect-virt", RESULT!="zvm", ATTR{state}=="offline", ATTR{state}="online"
 
 # reload sysctl.conf / sysctl.conf.d settings when the bridge module is loaded
 ACTION=="add", SUBSYSTEM=="module", KERNEL=="bridge", RUN+="/usr/lib/systemd/systemd-sysctl --prefix=/proc/sys/net/bridge"


### PR DESCRIPTION
Resolves: #1370161
