### PR TITLE
Recognise Lustre as a remote file system (#4530) (#1390542)

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -1924,7 +1924,11 @@ bool fstype_is_network(const char *fstype) {
                 "nfs4\0"
                 "gfs\0"
                 "gfs2\0"
-                "glusterfs\0";
+                "glusterfs\0"
+                "pvfs2\0" /* OrangeFS */
+                "ocfs2\0"
+                "lustre\0"
+                ;
 
         const char *x;
 


### PR DESCRIPTION
Lustre is also a remote file system that wants the network to be up before it is mounted.

Cherry-picked from: 67ae43665e7e03becba197e98df5b3ce40269567
Resolves: #1390542