### PR TITLE
manager: do not produce extraneous log message on EAGAIN (#1395676)

### DIFF
--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -1677,17 +1677,15 @@ static int manager_dispatch_notify_fd(sd_event_source *source, int fd, uint32_t 
 
                 n = recvmsg(m->notify_fd, &msghdr, MSG_DONTWAIT|MSG_CMSG_CLOEXEC);
                 if (n < 0) {
-                        if (errno == EAGAIN || errno == EINTR) {
+                        if (errno != EAGAIN && errno != EINTR)
                                 log_error("Failed to receive notification message: %m");
-                                break;
-                        }
 
                         /* It's not an option to return an error here since it
                         * would disable the notification handler entirely. Services
                         * wouldn't be able to send the WATCHDOG message for
                         * example... */
 
-                        continue;
+                        break;
                 }
 
                 for (cmsg = CMSG_FIRSTHDR(&msghdr); cmsg; cmsg = CMSG_NXTHDR(&msghdr, cmsg)) {


### PR DESCRIPTION
Once we process notification we start new iteration of for loop and if
no new notification message is queued then recvmsg returns EAGAIN. That
is expected and we should only log about errors other than EAGAIN and
EINTR.

RHEL-only

Resolves: #1395676