### PR TITLE
core: return 0 from device_serialize() (bz1403249)

### DIFF
--- a/src/core/device.c
+++ b/src/core/device.c
@@ -168,6 +168,8 @@ static int device_serialize(Unit *u, FILE *f, FDSet *fds) {
         assert(fds);
 
         unit_serialize_item(u, f, "state", device_state_to_string(d->state));
+
+        return 0;
 }
 
 static int device_deserialize_item(Unit *u, const char *key, const char *value, FDSet *fds) {


### PR DESCRIPTION
Fixes:

  CC       src/core/libsystemd_core_la-device.lo
src/core/device.c: In function 'device_serialize':
src/core/device.c:169:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^

Cherry-picked from: 0108f6ecc85eccc0177579f575d7bc3d56d43bc6
Resolves: #1403249