### PR TITLE
sd-journal: properly export has_{persistent|runtime}_files() (#1409527)

### DIFF
--- a/src/libsystemd/libsystemd.sym.m4
+++ b/src/libsystemd/libsystemd.sym.m4
@@ -163,6 +163,12 @@ global:
         sd_pid_notify_with_fds;
 } LIBSYSTEMD_217;
 
+LIBSYSTEMD_229 {
+global:
+        sd_journal_has_runtime_files;
+        sd_journal_has_persistent_files;
+} LIBSYSTEMD_219;
+
 m4_ifdef(`ENABLE_KDBUS',
 LIBSYSTEMD_FUTURE {
 global:


### PR DESCRIPTION
Cherry-picked from: 9a07f779bbeacc3358d405f6cf583506aaf655ae
Resolves: #1409527