### PR TITLE
tests: fix failure of test-execute if /dev/mem is not available (#1410056)

### DIFF
--- a/test/exec-privatedevices-no.service
+++ b/test/exec-privatedevices-no.service
@@ -2,6 +2,6 @@
 Description=Test for PrivateDev=no
 
 [Service]
-ExecStart=/bin/sh -c 'exit $(test -c /dev/mem)'
+ExecStart=/bin/sh -c 'exit $(test -c /dev/kmsg)'
 Type=oneshot
 PrivateDevices=no

--- a/test/exec-privatedevices-yes.service
+++ b/test/exec-privatedevices-yes.service
@@ -2,6 +2,6 @@
 Description=Test for PrivateDev=yes
 
 [Service]
-ExecStart=/bin/sh -c 'exit $(test ! -c /dev/mem)'
+ExecStart=/bin/sh -c 'exit $(test ! -c /dev/kmsg)'
 Type=oneshot
 PrivateDevices=yes


### PR DESCRIPTION
/dev/mem isn't necessarily available. Recently, I've encountered arm64
systems that didn't provide raw memory access via /dev/mem. Instead,
let's use /dev/kmsg since we don't support systems w/o it anyway.

Cherry-picked from: 01349f5d01e0b59168722403b0c1c2325b15512c
Resolves: #1410056