### PR TITLE
(bz#1413964) systemctl: fix 'is-enabled' exit status on failure when executed in c…

### DIFF
--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -5739,7 +5739,7 @@ static int unit_is_enabled(sd_bus *bus, char **args) {
 
                         r = unit_file_get_state(arg_scope, arg_root, *name, &state);
                         if (r < 0)
-                                return log_error_errno(state, "Failed to get unit file state for %s: %m", *name);
+                                return log_error_errno(r, "Failed to get unit file state for %s: %m", *name);
 
                         if (state == UNIT_FILE_ENABLED ||
                             state == UNIT_FILE_ENABLED_RUNTIME ||


### PR DESCRIPTION
…hroot (#4773)

(cherry picked from commit c5024cd05c194b93ae960bf38e567d3d998f2a03)
Resolves: #1413964