### PR TITLE
(#1416062) basic: fix touch() creating files with 07777 mode

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -3908,7 +3908,8 @@ int touch_file(const char *path, bool parents, usec_t stamp, uid_t uid, gid_t gi
         if (parents)
                 mkdir_parents(path, 0755);
 
-        fd = open(path, O_WRONLY|O_CREAT|O_CLOEXEC|O_NOCTTY, mode > 0 ? mode : 0644);
+        fd = open(path, O_WRONLY|O_CREAT|O_CLOEXEC|O_NOCTTY,
+                        (mode == 0 || mode == MODE_INVALID) ? 0644 : mode);
         if (fd < 0)
                 return -errno;
 


### PR DESCRIPTION
mode_t is unsigned, so MODE_INVALID < 0 can never be true.

This fixes a possible DoS where any user could fill /run by writing to
a world-writable /run/systemd/show-status.

Cherry-picked from: 06eeacb6fe029804f296b065b3ce91e796e1cd0e
Resolves: #1416062