### PR TITLE
udev: fix crash with invalid udev.log-priority (#1245293)

### DIFF
--- a/src/udev/udevd.c
+++ b/src/udev/udevd.c
@@ -990,7 +990,10 @@ static void kernel_cmdline_options(struct udev *udev) {
                         int prio;
 
                         prio = util_log_priority(value);
-                        log_set_max_level(prio);
+                        if (prio < 0)
+                                log_warning("Invalid udev.log-priority ignored: %s", value);
+                        else
+                                log_set_max_level(prio);
                 } else if ((value = startswith(opt, "udev.children-max="))) {
                         r = safe_atoi(value, &arg_children_max);
                         if (r < 0)


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1245293

Conflicts:
	src/udev/udevd.c

Cherry-picked from: e00f5bddde0daff900cbd93e1ee0530ad1ae06ce
Resolves: #1245293