### PR TITLE
(#1421658) core: if the start command vanishes during runtime don't hit an assert

### DIFF
--- a/src/core/service.c
+++ b/src/core/service.c
@@ -1563,7 +1563,15 @@ static void service_enter_start(Service *s) {
         }
 
         if (!c) {
-                assert(s->type == SERVICE_ONESHOT);
+                if (s->type != SERVICE_ONESHOT) {
+                        /* There's no command line configured for the main command? Hmm, that is strange. This can only
+                         * happen if the configuration changes at runtime. In this case, let's enter a failure
+                         * state. */
+                        log_unit_error(UNIT(s), "There's no 'start' task anymore we could start: %m");
+                        r = -ENXIO;
+                        goto fail;
+                }
+
                 service_enter_start_post(s);
                 return;
         }


### PR DESCRIPTION
This can happen when the configuration is changed and reloaded while we are
executing a service. Let's not hit an assert in this case.

Fixes: #4444

Cherry-picked from: 47fffb3530af3e3ad4048570611685635fde062e
Resolves: #1421658