### PR TITLE
udev/path_id: improve and enhance bus detection for Linux on z Systems (#1274401)

### DIFF
--- a/rules/40-redhat.rules
+++ b/rules/40-redhat.rules
@@ -15,3 +15,28 @@ SUBSYSTEM=="scsi", ENV{DEVTYPE}=="scsi_target", TEST!="[module/sg]", RUN+="/sbin
 
 # Rule for prandom character device node permissions
 KERNEL=="prandom", MODE="0644"
+
+
+# Rules for creating the ID_PATH for SCSI devices based on the CCW bus
+# using the form: ccw-<BUS_ID>-zfcp-<WWPN>:<LUN>
+#
+ACTION=="remove", GOTO="zfcp_scsi_device_end"
+
+#
+# Set environment variable "ID_ZFCP_BUS" to "1" if the devices
+# (both disk and partition) are SCSI devices based on FCP devices
+#
+KERNEL=="sd*", SUBSYSTEMS=="ccw", DRIVERS=="zfcp", ENV{.ID_ZFCP_BUS}="1"
+
+# For SCSI disks
+KERNEL=="sd*[!0-9]", SUBSYSTEMS=="scsi",
+        ENV{.ID_ZFCP_BUS}=="1", ENV{DEVTYPE}=="disk",
+        SYMLINK+="disk/by-path/ccw-$attr{hba_id}-zfcp-$attr{wwpn}:$attr{fcp_lun}"
+
+
+# For partitions on a SCSI disk
+KERNEL=="sd*[0-9]", SUBSYSTEMS=="scsi",
+        ENV{.ID_ZFCP_BUS}=="1", ENV{DEVTYPE}=="partition",
+        SYMLINK+="disk/by-path/ccw-$attr{hba_id}-zfcp-$attr{wwpn}:$attr{fcp_lun}-part%n"
+
+LABEL="zfcp_scsi_device_end"


### PR DESCRIPTION
Improve and enhance the path_id udev builtin to correctly handle bus'
available on Linux on z Systems (s390).

Previously, the CCW bus and, in particular, any FCP devices on it, have
been treated separately.  This commit integrates the CCW bus into the
device chain loop.  FCP devices and their associated SCSI disks are now
handled through the common SCSI handling functions in path_id.

This implies also a change in the naming of the symbolic links created
by udev.  So any backports of this commit to existing Linux distribution
must be done with care.  If a backport is required, a udev rule must be
created to also create the "old-style" symbolic links.

Apart from the CCW bus, this commit adds bus support for the:

- ccwgroup bus which manages network devices, and
- ap bus which manages cryptographic adapters
- iucv bus which manages IUCV devices on z/VM

Cherry-picked from: e7eb5a8d88367a755944fdda3023a308e5272953
Resolves: #1274401