### PR TITLE
sysv-generator: Provides: $network should also pull network.target to…

### DIFF
--- a/src/sysv-generator/sysv-generator.c
+++ b/src/sysv-generator/sysv-generator.c
@@ -500,6 +500,9 @@ static int load_sysv(SysvStub *s) {
                                                         r = strv_extend(&s->before, SPECIAL_NETWORK_TARGET);
                                                         if (r < 0)
                                                                 return log_oom();
+                                                        r = strv_extend(&s->wants, SPECIAL_NETWORK_TARGET);
+                                                        if (r < 0)
+                                                                return log_oom();
                                                 }
                                         }
 


### PR DESCRIPTION
… transaction (#5652)

network.target should be pulled in to the transaction
by the unit that provides network services, but currently
for initscripts it only pulls in network-online.target.

Cherry-picked from: bd9ad4ff5bf2252f46ccf0cb91b3ed16def1c1a4
Resolves: #1438749