### PR TITLE
util:bind_remount_recursive(): handle return 0 of set_consume()

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -7327,7 +7327,7 @@ int bind_remount_recursive(const char *prefix, bool ro) {
                 while ((x = set_steal_first(todo))) {
 
                         r = set_consume(done, x);
-                        if (r == -EEXIST)
+                        if (r == -EEXIST || r == 0)
                                 continue;
                         if (r < 0)
                                 return r;


### PR DESCRIPTION
set_consume() does not return -EEXIST, but 0, in case the key is already
in the Set.

Cherry-picked from: 85d834ae8e7d9e2c28ef8c1388e2913ed8fd0e3b
Resolves: #1433687