### PR TITLE
sd-journal: return SD_JOURNAL_INVALIDATE only if journal files were actually deleted/moved (#1446140)

### DIFF
--- a/src/journal/sd-journal.c
+++ b/src/journal/sd-journal.c
@@ -2190,6 +2190,7 @@ _public_ int sd_journal_process(sd_journal *j) {
         assert_return(!journal_pid_changed(j), -ECHILD);
 
         j->last_process_usec = now(CLOCK_MONOTONIC);
+        j->last_invalidate_counter = j->current_invalidate_counter;
 
         for (;;) {
                 union inotify_event_buffer buffer;


### PR DESCRIPTION
When caller invokes sd_journal_open() we usually open at least one
directory with journal files. add_root_directory() function increments
current_invalidate_counter. After sd_journal_open() returns
current_invalidate_counter != last_invalidate_counter.

After caller waits for journal events (e.g. waits for new messages in
journal) then it usually calls sd_journal_process(). However, on first
call to sd_journal_process(), function determine_change() returns
SD_JOURNAL_INVALIDATE even though no journal files were
deleted/moved. This is because current_invalidate_counter !=
last_invalidate_counter.

After the fix we make sure counters has the same value before we begin
processing inotify events.

(cherry picked from commit f934644424daa6c86fd2284fe8f33ea233ece874)

Resolves: #1446140