### PR TITLE
readahead: don't collect readahead profile when rootfs is read-only (#1268349)

### DIFF
--- a/units/systemd-readahead-collect.service.in
+++ b/units/systemd-readahead-collect.service.in
@@ -12,9 +12,11 @@ DefaultDependencies=no
 Wants=systemd-readahead-done.timer
 Conflicts=shutdown.target
 Before=sysinit.target shutdown.target
+After=systemd-remount-fs.service
 ConditionPathExists=!/run/systemd/readahead/cancel
 ConditionPathExists=!/run/systemd/readahead/done
 ConditionVirtualization=no
+ConditionPathIsReadWrite=/
 
 [Service]
 Type=notify


### PR DESCRIPTION
We wouldn't be able write the pack file, so don't bother collecting data
either.

RHEL-only

Resolves: #1268349