### PR TITLE
fstab-generator: remove bogus condition (#1446171)

### DIFF
--- a/src/fstab-generator/fstab-generator.c
+++ b/src/fstab-generator/fstab-generator.c
@@ -476,8 +476,6 @@ static int parse_fstab(bool initrd) {
                                                       "x-systemd.automount\0");
                         if (initrd)
                                 post = SPECIAL_INITRD_FS_TARGET;
-                        else if (mount_in_initrd(me))
-                                post = SPECIAL_INITRD_ROOT_FS_TARGET;
                         else if (mount_is_network(me))
                                 post = SPECIAL_REMOTE_FS_TARGET;
                         else


### PR DESCRIPTION
The sysroot mount is already taken care of by the add_sysroot_mount function. With this condition left in, we can get something like this:

initrd-root-fs.target.requires
`-- usr.mount -> /run/systemd/generator/usr.mount

in the main system (i.e., not in the initramfs). In the initramfs, the previous condition already kicks in.
Cherry-picked from: ce3f6d82b003f365f718f24e48f55b8a0372b924
Resolves: #1446171