### PR TITLE
readahead-collect: don't print warning message when handling symlink (#1387095)

### DIFF
--- a/src/readahead/readahead-collect.c
+++ b/src/readahead/readahead-collect.c
@@ -106,6 +106,9 @@ static int pack_file(FILE *pack, const char *fn, bool on_btrfs) {
                 if (errno == EPERM || errno == EACCES)
                         return 0;
 
+                if (errno == ELOOP)
+                        return 0;
+
                 log_warning("open(%s) failed: %m", fn);
                 r = -errno;
                 goto finish;


### PR DESCRIPTION
Since we call open() with O_NOFOLLOW we can't really open symlinks (we
would need to add O_PATH and we don't want that). Let's shortcut things
and return immediately, but don't treat this as an error.

Resolves: #1387095