### PR TITLE
(#1437114) core:execute: fix fork() fail handling in exec_spawn()

### DIFF
--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -1977,7 +1977,7 @@ int exec_spawn(ExecCommand *command,
                         NULL);
         pid = fork();
         if (pid < 0)
-                return log_unit_error_errno(params->unit_id, r, "Failed to fork: %m");
+                return log_unit_error_errno(params->unit_id, errno, "Failed to fork: %m");
 
         if (pid == 0) {
                 int exit_status;


### PR DESCRIPTION
    If pid < 0 after fork(), 0 is always returned because r =
    exec_context_load_environment() has exited successfully.

    This will make the caller of exec_spawn() not able to handle
    the fork() error case and make systemd abort assert() possibly.

Cherry-picked from:
Resolves: #