### PR TITLE
 #1477285 Revert "udev: net_id: add support for phys_port_name attribute (#4506)"

### DIFF
--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -38,7 +38,7 @@
  *   o<index>[d<dev_port>]                 -- on-board device index number
  *   s<slot>[f<function>][d<dev_port>]     -- hotplug slot index number
  *   x<MAC>                                -- MAC address
- *   [P<domain>]p<bus>s<slot>[f<function>][n<phys_port_name>|d<dev_id>/<dev_port>]
+ *   [P<domain>]p<bus>s<slot>[f<function>][d<dev_id>/<dev_port>]
  *                                         -- PCI geographical location
  *   [P<domain>]p<bus>s<slot>[f<function>][u<port>][..][c<config>][i<interface>]
  *                                         -- USB port number chain
@@ -134,7 +134,7 @@ static int dev_pci_onboard(struct udev_device *dev, struct netnames *names) {
         unsigned dev_port = 0;
         size_t l;
         char *s;
-        const char *attr, *port_name;
+        const char *attr;
         int idx;
 
         /* ACPI _DSM  -- device specific method for naming a PCI or PCI Express device */
@@ -161,15 +161,10 @@ static int dev_pci_onboard(struct udev_device *dev, struct netnames *names) {
         if (attr)
                 dev_port = strtol(attr, NULL, 10);
 
-        /* kernel provided front panel port name for multiple port PCI device */
-        port_name = udev_device_get_sysattr_value(dev, "phys_port_name");
-
         s = names->pci_onboard;
         l = sizeof(names->pci_onboard);
         l = strpcpyf(&s, l, "o%d", idx);
-        if (port_name)
-                l = strpcpyf(&s, l, "n%s", port_name);
-        else if (dev_port > 0)
+        if (dev_port > 0)
                 l = strpcpyf(&s, l, "d%d", dev_port);
         if (l == 0)
                 names->pci_onboard[0] = '\0';
@@ -204,7 +199,7 @@ static int dev_pci_slot(struct udev_device *dev, struct netnames *names) {
         unsigned domain, bus, slot, func, dev_id = 0;
         size_t l;
         char *s;
-        const char *attr, *port_name;
+        const char *attr;
         struct udev_device *pci = NULL;
         char slots[256], str[256];
         _cleanup_closedir_ DIR *dir = NULL;
@@ -225,9 +220,6 @@ static int dev_pci_slot(struct udev_device *dev, struct netnames *names) {
                 }
         }
 
-        /* kernel provided front panel port name for multiple port PCI device */
-        port_name = udev_device_get_sysattr_value(dev, "phys_port_name");
-
         /* compose a name based on the raw kernel's PCI bus, slot numbers */
         s = names->pci_path;
         l = sizeof(names->pci_path);
@@ -236,9 +228,7 @@ static int dev_pci_slot(struct udev_device *dev, struct netnames *names) {
         l = strpcpyf(&s, l, "p%us%u", bus, slot);
         if (func > 0 || is_pci_multifunction(names->pcidev))
                 l = strpcpyf(&s, l, "f%d", func);
-        if (port_name)
-                l = strpcpyf(&s, l, "n%s", port_name);
-        else if (dev_id > 0)
+        if (dev_id > 0)
                 l = strpcpyf(&s, l, "d%d", dev_id);
         if (l == 0)
                 names->pci_path[0] = '\0';
@@ -288,9 +278,7 @@ static int dev_pci_slot(struct udev_device *dev, struct netnames *names) {
                 l = strpcpyf(&s, l, "s%d", hotplug_slot);
                 if (func > 0 || is_pci_multifunction(names->pcidev))
                         l = strpcpyf(&s, l, "f%d", func);
-                if (port_name)
-                        l = strpcpyf(&s, l, "n%s", port_name);
-                else if (dev_id > 0)
+                if (dev_id > 0)
                         l = strpcpyf(&s, l, "d%d", dev_id);
                 if (l == 0)
                         names->pci_slot[0] = '\0';


### PR DESCRIPTION
This reverts commit 192545bc67fed763ac54761ca067b9c2f93ecdd1.

This caused change of the names for sfc driver.

Resolves: #1477285