### PR TITLE
(#1420505) log: never log into foreign fd #2 in PID 1 or its pre-execve() children

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1311,9 +1311,16 @@ int main(int argc, char *argv[]) {
         log_show_color(isatty(STDERR_FILENO) > 0);
         log_set_upgrade_syslog_to_journal(true);
 
-        /* Disable the umask logic */
-        if (getpid() == 1)
+        if (getpid() == 1) {
+                /* Disable the umask logic */
                 umask(0);
+
+                /* Always reopen /dev/console when running as PID 1 or one of its pre-execve() children. This is
+                 * important so that we never end up logging to any foreign stderr, for example if we have to log in a
+                 * child process right before execve()'ing the actual binary, at a point in time where socket
+                 * activation stderr/stdout area already set up. */
+                log_set_always_reopen_console(true);
+        }
 
         if (getpid() == 1 && detect_container(NULL) <= 0) {
 

--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -52,6 +52,7 @@ static bool show_color = false;
 static bool show_location = false;
 
 static bool upgrade_syslog_to_journal = false;
+static bool always_reopen_console = false;
 
 /* Akin to glibc's __abort_msg; which is private and we hence cannot
  * use here. */
@@ -75,7 +76,7 @@ static int log_open_console(void) {
         if (console_fd >= 0)
                 return 0;
 
-        if (getpid() == 1) {
+        if (always_reopen_console) {
                 console_fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY|O_CLOEXEC);
                 if (console_fd < 0)
                         return console_fd;
@@ -1060,4 +1061,8 @@ void log_received_signal(int level, const struct signalfd_siginfo *si) {
 
 void log_set_upgrade_syslog_to_journal(bool b) {
         upgrade_syslog_to_journal = b;
+}
+
+void log_set_always_reopen_console(bool b) {
+        always_reopen_console = b;
 }

--- a/src/shared/log.h
+++ b/src/shared/log.h
@@ -210,3 +210,4 @@ LogTarget log_target_from_string(const char *s) _pure_;
 void log_received_signal(int level, const struct signalfd_siginfo *si);
 
 void log_set_upgrade_syslog_to_journal(bool b);
+void log_set_always_reopen_console(bool b);


### PR DESCRIPTION
(cherry picked from commit 48a601fe5de8aa0d89ba6dadde168769fa7ce992)
Resolves: #1420505