### PR TITLE
sysctl: fix uninitialized variable (#1485121)

### DIFF
--- a/src/sysctl/sysctl.c
+++ b/src/sysctl/sysctl.c
@@ -91,7 +91,7 @@ static int apply_sysctl(const char *property, const char *value) {
 }
 
 static int apply_all(OrderedHashmap *sysctl_options) {
-        int r;
+        int r = 0;
         char *property, *value;
         Iterator i;
 


### PR DESCRIPTION
RHEL-only

Reported-by: HATAYAMA Daisuke <d.hatayama@jp.fujitsu.com>

Resolves: #1485121