### PR TITLE
(#1493047) core/namespace: Protect /usr instead of /home with ProtectSystem=yes

### DIFF
--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -521,7 +521,7 @@ int setup_namespace(
                 if (protect_system != PROTECT_SYSTEM_NO) {
                         const char *usr_dir, *boot_dir, *etc_dir;
 
-                        usr_dir = prefix_roota(root_directory, "/home");
+                        usr_dir = prefix_roota(root_directory, "/usr");
                         boot_dir = prefix_roota(root_directory, "/boot");
                         boot_dir = strjoina("-", boot_dir);
                         etc_dir = prefix_roota(root_directory, "/etc");


### PR DESCRIPTION
A small typo in ee818b8 caused /home to be put in read-only instead of
/usr when ProtectSystem was enabled (ie: not set to "no").

(cherry picked from commit d38e01dc96c5cae1986561c4f3bc7f760560bf2a)

Resolves: #1493047