### PR TITLE
device: make sure to remove all device units sharing the same sysfs path  (#1408916)

### DIFF
--- a/src/core/device.c
+++ b/src/core/device.c
@@ -487,7 +487,7 @@ static void device_update_found_one(Device *d, bool add, DeviceFound found, bool
 }
 
 static int device_update_found_by_sysfs(Manager *m, const char *sysfs, bool add, DeviceFound found, bool now) {
-        Device *d, *l;
+        Device *d, *l, *n;
 
         assert(m);
         assert(sysfs);
@@ -496,7 +496,7 @@ static int device_update_found_by_sysfs(Manager *m, const char *sysfs, bool add,
                 return 0;
 
         l = hashmap_get(m->devices_by_sysfs, sysfs);
-        LIST_FOREACH(same_sysfs, d, l)
+        LIST_FOREACH_SAFE(same_sysfs, d, n, l)
                 device_update_found_one(d, add, found, now);
 
         return 0;


### PR DESCRIPTION
When a device is unplugged all device units sharing the same sysfs path
pointing to that device are supposed to be removed.

However it didn't work since while iterating the device unit list containing
all the relevant units, each unit was removed during each iteration of
LIST_FOREACH. However LIST_FOREACH doesn't support this use case and
LIST_FOREACH_SAFE must be use instead.

(cherry picked from commit cc0df6cc35339976c367977dc292278a1939db0c)

Related: #1408916