### PR TITLE
(#1494610) Support 'rdma' as a ListenNetlink= argument

### DIFF
--- a/src/shared/socket-util.c
+++ b/src/shared/socket-util.c
@@ -725,7 +725,8 @@ static const char* const netlink_family_table[] = {
         [NETLINK_KOBJECT_UEVENT] = "kobject-uevent",
         [NETLINK_GENERIC] = "generic",
         [NETLINK_SCSITRANSPORT] = "scsitransport",
-        [NETLINK_ECRYPTFS] = "ecryptfs"
+        [NETLINK_ECRYPTFS] = "ecryptfs",
+        [NETLINK_RDMA] = "rdma",
 };
 
 DEFINE_STRING_TABLE_LOOKUP_WITH_FALLBACK(netlink_family, int, INT_MAX);


### PR DESCRIPTION
NETLINK_RDMA has been in the kernel since v3.0.

(cherry-picked from commit 5570d7f9561294271591881cf9a249d574069c30)

Resolves: #1494610