### PR TITLE
udev: Use parent bus id for virtio disk builtin path-id (#1496697)

### DIFF
--- a/rules/60-persistent-storage.rules
+++ b/rules/60-persistent-storage.rules
@@ -71,6 +71,10 @@ ENV{DEVTYPE}=="partition", ENV{ID_SAS_PATH}=="?*", SYMLINK+="disk/by-path/$env{I
 # skip unpartitioned removable media devices from drivers which do not send "change" events
 ENV{DEVTYPE}=="disk", KERNEL!="sd*|sr*", ATTR{removable}=="1", GOTO="persistent_storage_end"
 
+# legacy virtio-pci by-path links (deprecated)
+KERNEL=="vd*[!0-9]", ENV{ID_PATH}=="pci-*", SYMLINK+="disk/by-path/virtio-$env{ID_PATH}"
+KERNEL=="vd*[0-9]", ENV{ID_PATH}=="pci-*", SYMLINK+="disk/by-path/virtio-$env{ID_PATH}-part%n"
+
 # probe filesystem metadata of optical drives which have a media inserted
 KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", ENV{ID_CDROM_MEDIA_TRACK_COUNT_DATA}=="?*", ENV{ID_CDROM_MEDIA_SESSION_LAST_OFFSET}=="?*", \
   IMPORT{builtin}="blkid --offset=$env{ID_CDROM_MEDIA_SESSION_LAST_OFFSET}"

--- a/src/udev/udev-builtin-path_id.c
+++ b/src/udev/udev-builtin-path_id.c
@@ -688,11 +688,8 @@ restart:
                         parent = skip_subsystem(parent, "xen");
                         supported_parent = true;
                 } else if (streq(subsys, "virtio")) {
-                        while (parent && streq_ptr("virtio", udev_device_get_subsystem(parent)))
-                                parent = udev_device_get_parent(parent);
-                        path_prepend(&path, "virtio-pci-%s", udev_device_get_sysname(parent));
+                        parent = skip_subsystem(parent, "virtio");
                         supported_transport = true;
-                        supported_parent = true;
                 } else if (streq(subsys, "scm")) {
                         path_prepend(&path, "scm-%s", udev_device_get_sysname(parent));
                         parent = skip_subsystem(parent, "scm");


### PR DESCRIPTION
The builtin path id for virtio block devices has been changed
to use the bus id without a prefix "virtio-pci" to be
compatible with all virtio transport types.

In order to not break existing setups, the by-path symlinks for
virtio block devices on the PCI bus are reintroduced by udev rules.
The virtio-pci symlinks are considered to be deprecated and
should be replaced by the native PCI symlinks.

Example output for a virtio disk in PCI slot 7:
 $ ls  /dev/disk/by-path
 pci-0000:00:07.0
 pci-0000:00:07.0-part1
 virtio-pci-0000:00:07.0
 virtio-pci-0000:00:07.0-part1

See also
[1] https://lists.freedesktop.org/archives/systemd-devel/2017-February/038326.html
[2] https://lists.freedesktop.org/archives/systemd-devel/2017-March/038397.html

This reverts f073b1b but keeps the same symlinks for compatibility.

(cherry picked from commit fb92fbb1b171ef94207a1ebc111ef0e414d49b4c)

Resolves: #1496697