### PR TITLE
(#1476910) scsi_id: add missing options to getopt_long() (#6501)

### DIFF
--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -333,7 +333,7 @@ static int set_options(struct udev *udev,
          * file) we have to reset this back to 1.
          */
         optind = 1;
-        while ((option = getopt_long(argc, argv, "d:f:gp:uvVxh", options, NULL)) >= 0)
+        while ((option = getopt_long(argc, argv, "d:f:gp:uvVxhbs:", options, NULL)) >= 0)
                 switch (option) {
                 case 'b':
                         all_good = false;


### PR DESCRIPTION
(cherry picked from commit ebc6f34a0b2359ac0da41037a1122d3abe02caee)

Resolves: #1476910