### PR TITLE
(#1501017) journald: never accept fds from file systems with mandatory locking e…

### DIFF
--- a/src/journal/journald-native.c
+++ b/src/journal/journald-native.c
@@ -23,6 +23,7 @@
 #include <stddef.h>
 #include <sys/epoll.h>
 #include <sys/mman.h>
+#include <sys/statvfs.h>
 
 #include "socket-util.h"
 #include "path-util.h"
@@ -391,7 +392,36 @@ void server_process_native_file(
                 assert_se(munmap(p, ps) >= 0);
         } else {
                 _cleanup_free_ void *p = NULL;
+                struct statvfs vfs;
                 ssize_t n;
+
+                if (fstatvfs(fd, &vfs) < 0) {
+                        log_error_errno(errno, "Failed to stat file system of passed file, ignoring: %m");
+                        return;
+                }
+
+                /* Refuse operating on file systems that have
+                 * mandatory locking enabled, see:
+                 *
+                 * https://github.com/systemd/systemd/issues/1822
+                 */
+                if (vfs.f_flag & ST_MANDLOCK) {
+                        log_error("Received file descriptor from file system with mandatory locking enable, refusing.");
+                        return;
+                }
+
+                /* Make the fd non-blocking. On regular files this has
+                 * the effect of bypassing mandatory locking. Of
+                 * course, this should normally not be necessary given
+                 * the check above, but let's better be safe than
+                 * sorry, after all NFS is pretty confusing regarding
+                 * file system flags, and we better don't trust it,
+                 * and so is SMB. */
+                r = fd_nonblock(fd, true);
+                if (r < 0) {
+                        log_error_errno(r, "Failed to make fd non-blocking, ignoring: %m");
+                        return;
+                }
 
                 /* The file is not sealed, we can't map the file here, since
                  * clients might then truncate it and trigger a SIGBUS for


### PR DESCRIPTION
…nabled

This is pretty much a work-around for a security vulnerability in
kernels that allow unprivileged user namespaces.

Fixes #1822.

Cherry-picked from: 1e603a482f57edb1fb863dbf23b868cf5854e004
Resolves: #1501017