### PR TITLE
(#1472439) test-path-util: force rm_rf

### DIFF
--- a/src/test/test-path-util.c
+++ b/src/test/test-path-util.c
@@ -157,7 +157,7 @@ static void test_path_is_mount_point(void) {
         } else
                 printf("Skipping bind mount file test: %m\n");
 
-        assert_se(rm_rf(tmp_dir, false, true, false) == 0);
+        assert_se(rm_rf_dangerous(tmp_dir, false, true, false) == 0);
 }
 
 static void test_find_binary(const char *self, bool local) {


### PR DESCRIPTION
On rhel we don't have tmpfs in /tmp, so simple rm_rf will
refuse to remove the test directory.

RHEL-only

Related: #1472439