### PR TITLE
(#1505385) journal-remote: make --url option support arbitrary url

### DIFF
--- a/src/journal-remote/journal-remote.c
+++ b/src/journal-remote/journal-remote.c
@@ -894,7 +894,14 @@ static int remoteserver_init(RemoteServer *s,
         if (arg_url) {
                 const char *url, *hostname;
 
-                url = strjoina(arg_url, "/entries");
+                if (!strstr(arg_url, "/entries")) {
+                        if (endswith(arg_url, "/"))
+                                url = strjoina(arg_url, "entries");
+                        else
+                                url = strjoina(arg_url, "/entries");
+                }
+                else
+                        url = strdupa(arg_url);
 
                 if (arg_getter) {
                         log_info("Spawning getter %s...", url);


### PR DESCRIPTION
Currently, --url option supports the only form like http(s)://some.host:19531.
This commit adds support to call systemd-journal-remote as follwos:
systemd-journal-remote --url='http://some.host:19531'
systemd-journal-remote --url='http://some.host:19531/'
systemd-journal-remote --url='http://some.host:19531/entries'
systemd-journal-remote --url='http://some.host:19531/entries?boot&follow'
The first three example result the same and retrieve all entries.
The last example retrieves only current boot entries and wait new events.

Cherry-picked from: b68f6b0a794f9e6cb6457a0ac55041c4e7b1a5cb
Resolves: #1505385