### PR TITLE
manager: fix connecting to bus when dbus is actually around (#1465737)

### DIFF
--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -809,7 +809,7 @@ static int manager_connect_bus(Manager *m, bool reexecuting) {
         u = manager_get_unit(m, SPECIAL_DBUS_SERVICE);
 
         try_bus_connect =
-                (u && UNIT_IS_ACTIVE_OR_RELOADING(unit_active_state(u))) &&
+                (u && SERVICE(u)->deserialized_state == SERVICE_RUNNING) &&
                 (reexecuting ||
                 (m->running_as == SYSTEMD_USER && getenv("DBUS_SESSION_BUS_ADDRESS")));
 


### PR DESCRIPTION
manager_connect_bus() is called *before* manager_coldplug(). As a last
thing in service_coldplug() we set service state to
s->deserialized_state, and thus before we do that all services are
inactive and try_connect always evaluates to false. To fix that we must
look at deserialized state instead of current unit state.

Fixes #7146

(cherry picked from commit 41dfa61d35c51a584437481d20541d5c3ccfa93d)

Related: #1465737