### PR TITLE
(#1431687) journal: Add support to read lz4 compressed journals

### DIFF
--- a/src/journal/compress.h
+++ b/src/journal/compress.h
@@ -35,15 +35,9 @@ int compress_blob_lz4(const void *src, uint64_t src_size, void *dst, size_t *dst
 
 static inline int compress_blob(const void *src, uint64_t src_size, void *dst, size_t *dst_size) {
         int r;
-#ifdef HAVE_LZ4
-        r = compress_blob_lz4(src, src_size, dst, dst_size);
-        if (r == 0)
-                return OBJECT_COMPRESSED_LZ4;
-#else
         r = compress_blob_xz(src, src_size, dst, dst_size);
         if (r == 0)
                 return OBJECT_COMPRESSED_XZ;
-#endif
         return r;
 }
 
@@ -75,12 +69,7 @@ int compress_stream_lz4(int fdf, int fdt, off_t max_bytes);
 int decompress_stream_xz(int fdf, int fdt, off_t max_size);
 int decompress_stream_lz4(int fdf, int fdt, off_t max_size);
 
-#ifdef HAVE_LZ4
-#  define compress_stream compress_stream_lz4
-#  define COMPRESSED_EXT ".lz4"
-#else
 #  define compress_stream compress_stream_xz
 #  define COMPRESSED_EXT ".xz"
-#endif
 
 int decompress_stream(const char *filename, int fdf, int fdt, off_t max_bytes);

--- a/src/journal/journal-file.c
+++ b/src/journal/journal-file.c
@@ -2615,9 +2615,8 @@ int journal_file_open(
         f->flags = flags;
         f->prot = prot_from_flags(flags);
         f->writable = (flags & O_ACCMODE) != O_RDONLY;
-#if defined(HAVE_LZ4)
-        f->compress_lz4 = compress;
-#elif defined(HAVE_XZ)
+
+#if defined(HAVE_XZ)
         f->compress_xz = compress;
 #endif
 #ifdef HAVE_GCRYPT


### PR DESCRIPTION
Functionality already in codebase, but deactivated in RHEL
Changed calling of LZ4 functions due to deprecation of the originals.
Resolves: rhbz#1431687

changes to .spec file:

@@ -552,6 +553,7 @@ BuildRequires:  libblkid-devel
 BuildRequires:  xz-devel
 BuildRequires:  zlib-devel
 BuildRequires:  bzip2-devel
+BuildRequires:  lz4-devel
 BuildRequires:  libidn-devel
 BuildRequires:  libcurl-devel
 BuildRequires:  kmod-devel
@@ -742,6 +744,7 @@ CONFIGURE_OPTS=(
     --enable-compat-libs
     --disable-sysusers
     --disable-ldconfig
+    --enable-lz4
 %ifarch s390 s390x ppc %{power64} aarch64
     --disable-lto
 %endif