### PR TITLE
(#1489095) shared/dropin: ignore ENAMETOOLONG when checking drop-in directories …

### DIFF
--- a/src/shared/dropin.c
+++ b/src/shared/dropin.c
@@ -129,8 +129,12 @@ static int iterate_dir(
 
         d = opendir(path);
         if (!d) {
-                if (errno == ENOENT)
-                        return 0;
+                /* Ignore ENOENT, after all most units won't have a drop-in dir.
+                 * Also ignore ENAMETOOLONG, users are not even able to create
+                 * the drop-in dir in such case. This mostly happens for device units with long /sys path.
+                 * */
+                if (IN_SET(errno, ENOENT, ENAMETOOLONG))
+                            return 0;
 
                 log_error_errno(errno, "Failed to open directory %s: %m", path);
                 return -errno;


### PR DESCRIPTION
…(#7525)

This usually happens for device units with long
path in /sys. But users can't even create such drop-ins,
so lets just ignore the error here.

Fixes #6867

Cherry-picked from: dfeec916b57b593ce07d3751aebdb0cce1d05201
Resolves: #1489095