### PR TITLE
(#1302305) core: fix the reversed sanity check when setting StartupBlockIOWeight…

### DIFF
--- a/src/core/dbus-cgroup.c
+++ b/src/core/dbus-cgroup.c
@@ -324,7 +324,7 @@ int bus_cgroup_set_property(
                 if (r < 0)
                         return r;
 
-                if (CGROUP_BLKIO_WEIGHT_IS_OK(weight))
+                if (!CGROUP_BLKIO_WEIGHT_IS_OK(weight))
                         return sd_bus_error_set_errnof(error, EINVAL, "StartupBlockIOWeight value out of range");
 
                 if (mode != UNIT_CHECK) {


### PR DESCRIPTION
… over dbus

bus_cgroup_set_property() was rejecting if the input value was in range.
Reverse it.

Cherry-picked from: 6fb09269769634df1096663ce90fac47585eb63a
Resolves: #1302305-one-more-backport