### PR TITLE
(#1532586) shared/cgroup-utils: _CGROUP_CONTROLLER_MASK_ALL does not cover CGROU…

### DIFF
--- a/src/shared/cgroup-util.h
+++ b/src/shared/cgroup-util.h
@@ -36,7 +36,7 @@ typedef enum CGroupControllerMask {
         CGROUP_MEMORY = 8,
         CGROUP_DEVICE = 16,
         CGROUP_PIDS = 32,
-        _CGROUP_CONTROLLER_MASK_ALL = 31
+        _CGROUP_CONTROLLER_MASK_ALL = 63
 } CGroupControllerMask;
 
 /* Special values for the cpu.shares attribute */


### PR DESCRIPTION
…P_PIDS

7d44d0d43465892d4753ff50592588f49d56cf95 added a CGROUP_PIDS but
did not bump _CGROUP_CONTROLLER_MASK_ALL.

RHEL-only
Resolves: #1532586

Fixes #180 