### PR TITLE
units: don't put udev to its own mount namespace with slave propagation (#1432211)

### DIFF
--- a/units/systemd-udevd.service.in
+++ b/units/systemd-udevd.service.in
@@ -21,5 +21,4 @@ Sockets=systemd-udevd-control.socket systemd-udevd-kernel.socket
 Restart=always
 RestartSec=0
 ExecStart=@rootlibexecdir@/systemd-udevd
-MountFlags=slave
 KillMode=mixed


### PR DESCRIPTION
Change in upstream was done mostly for political reasons to discourage
people from doing mounts in udev rules. RHEL is very bad place for
such experiments. Revert to default we shipped with RHEL-7 GA.

RHEL-only

Resolves: #1432211