### PR TITLE
(#1501017) journald-native: Fix typo in MANDLOCK message

### DIFF
--- a/src/journal/journald-native.c
+++ b/src/journal/journald-native.c
@@ -406,7 +406,7 @@ void server_process_native_file(
                  * https://github.com/systemd/systemd/issues/1822
                  */
                 if (vfs.f_flag & ST_MANDLOCK) {
-                        log_error("Received file descriptor from file system with mandatory locking enable, refusing.");
+                        log_error("Received file descriptor from file system with mandatory locking enabled, refusing.");
                         return;
                 }
 


### PR DESCRIPTION
Cherry-picked from: 1dc52f56f9641be12470be664d16043a7a08ff37
Resolves: #1501017