### PR TITLE
dbus: propagate errors from bus_init_system() and bus_init_api() (#1541061)

### DIFF
--- a/src/core/dbus.c
+++ b/src/core/dbus.c
@@ -811,27 +811,21 @@ static int bus_init_api(Manager *m) {
                 else
                         r = sd_bus_open_user(&bus);
 
-                if (r < 0) {
-                        log_debug("Failed to connect to API bus, retrying later...");
-                        return 0;
-                }
+                if (r < 0)
+                        return log_error_errno(r, "Failed to connect to API bus: %m");
 
                 r = sd_bus_attach_event(bus, m->event, SD_EVENT_PRIORITY_NORMAL);
-                if (r < 0) {
-                        log_error_errno(r, "Failed to attach API bus to event loop: %m");
-                        return 0;
-                }
+                if (r < 0)
+                        return log_error_errno(r, "Failed to attach API bus to event loop: %m");
 
                 r = bus_setup_disconnected_match(m, bus);
                 if (r < 0)
-                        return 0;
+                        return r;
         }
 
         r = bus_setup_api(m, bus);
-        if (r < 0) {
-                log_error_errno(r, "Failed to set up API bus: %m");
-                return 0;
-        }
+        if (r < 0)
+                return log_error_errno(r, "Failed to set up API bus: %m");
 
         m->api_bus = bus;
         bus = NULL;
@@ -880,26 +874,20 @@ static int bus_init_system(Manager *m) {
         }
 
         r = sd_bus_open_system(&bus);
-        if (r < 0) {
-                log_debug("Failed to connect to system bus, retrying later...");
-                return 0;
-        }
+        if (r < 0)
+                return log_error_errno(r, "Failed to connect to system bus: %m");
 
         r = bus_setup_disconnected_match(m, bus);
         if (r < 0)
-                return 0;
+                return r;
 
         r = sd_bus_attach_event(bus, m->event, SD_EVENT_PRIORITY_NORMAL);
-        if (r < 0) {
-                log_error_errno(r, "Failed to attach system bus to event loop: %m");
-                return 0;
-        }
+        if (r < 0)
+                return log_error_errno(r, "Failed to attach system bus to event loop: %m");
 
         r = bus_setup_system(m, bus);
-        if (r < 0) {
-                log_error_errno(r, "Failed to set up system bus: %m");
-                return 0;
-        }
+        if (r < 0)
+                return log_error_errno(r, "Failed to set up system bus: %m");
 
         m->system_bus = bus;
         bus = NULL;
@@ -984,16 +972,16 @@ int bus_init(Manager *m, bool try_bus_connect) {
         if (try_bus_connect) {
                 r = bus_init_system(m);
                 if (r < 0)
-                        return r;
+                        return log_error_errno(r, "Failed to initialize D-Bus connection: %m");
 
                 r = bus_init_api(m);
                 if (r < 0)
-                        return r;
+                        return log_error_errno(r, "Error occured during D-Bus APIs initialization: %m");
         }
 
         r = bus_init_private(m);
         if (r < 0)
-                return r;
+                return log_error_errno(r, "Failed to create private D-Bus server: %m");
 
         return 0;
 }


### PR DESCRIPTION
The aim of this change is to make sure that we properly log about all
D-Bus connection problems. After all, we only ever attempt to get on the
bus if dbus-daemon is around, so any failure in the process should be
treated as an error.

bus_init_system() is only called from bus_init() and in
bus_init() we have a bool flag which governs whether we should attempt
to connect to the system bus or not.
Hence if we are in bus_init_system() then it is clear we got called from
a context where connection to the bus is actually required and therefore
shouldn't be treated as the "best effort" type of operation. Same
applies to bus_init_api().

We make use of those error codes in bus_init() and log high level
message that informs admin about what is going on (and is easy to spot
and makes sense to an end user).

Also "retrying later" bit is actually a lie. We won't retry unless we
are explicitly told to reconnect via SIGUSR1 or re-executed. This is
because bus_init() is always called from the context where dbus-daemon
is already around and hence bus_init() won't be called again from
unit_notify().

Fixes #7782

(cherry picked from commit dc7118ba094415d8de3812881cc5cbe2e3cac73e)

Resolves: #1541061