### PR TITLE
process-util: make our freeze() routine do something useful (#1540941)

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -4158,6 +4158,17 @@ noreturn void freeze(void) {
 
         sync();
 
+        /* Let's not freeze right away, but keep reaping zombies. */
+        for (;;) {
+                int r;
+                siginfo_t si = {};
+
+                r = waitid(P_ALL, 0, &si, WEXITED);
+                if (r < 0 && errno != EINTR)
+                        break;
+        }
+
+        /* waitid() failed with an unexpected error, things are really borked. Freeze now! */
         for (;;)
                 pause();
 }


### PR DESCRIPTION
When we crash we freeze() our-self (or possibly we reboot the machine if
that is configured). However, calling pause() is very unhelpful thing to
do. We should at least continue to do what init systems being doing
since 70's and that is reaping zombies. Otherwise zombies start to
accumulate on the system which is a very bad thing. As that can prevent
admin from taking manual steps to reboot the machine in somewhat
graceful manner (e.g. manually stopping services, unmounting data
volumes  and calling reboot -f).

Fixes #7783

(cherry picked from commit 8647283e453e4039029e2b21270241fa4010b3d8)

Resolves: #1540941