### PR TITLE
(#1542391) core: Let two more booleans survive a daemon-reload

### DIFF
--- a/src/core/service.c
+++ b/src/core/service.c
@@ -2044,6 +2044,7 @@ static int service_serialize(Unit *u, FILE *f, FDSet *fds) {
                 unit_serialize_item_format(u, f, "main-pid", PID_FMT, s->main_pid);
 
         unit_serialize_item(u, f, "main-pid-known", yes_no(s->main_pid_known));
+        unit_serialize_item(u, f, "bus-name-good", yes_no(s->bus_name_good));
 
         if (s->status_text)
                 unit_serialize_item(u, f, "status-text", s->status_text);
@@ -2264,6 +2265,14 @@ static int service_deserialize_item(Unit *u, const char *key, const char *value,
                         log_unit_debug(u->id, "Failed to parse main-pid-known value %s", value);
                 else
                         s->main_pid_known = b;
+        } else if (streq(key, "bus-name-good")) {
+                int b;
+
+                b = parse_boolean(value);
+                if (b < 0)
+                        log_unit_debug(u->id, "Failed to parse bus-name-good value: %s", value);
+                else
+                        s->bus_name_good = b;
         } else if (streq(key, "status-text")) {
                 char *t;
 

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -2619,6 +2619,7 @@ int unit_serialize(Unit *u, FILE *f, FDSet *fds, bool serialize_jobs) {
 
         if (u->cgroup_path)
                 unit_serialize_item(u, f, "cgroup", u->cgroup_path);
+        unit_serialize_item(u, f, "cgroup-realized", yes_no(u->cgroup_realized));
 
         if (serialize_jobs) {
                 if (u->job) {
@@ -2808,6 +2809,16 @@ int unit_deserialize(Unit *u, FILE *f, FDSet *fds) {
 
                         u->cgroup_path = s;
                         assert(hashmap_put(u->manager->cgroup_unit, s, u) == 1);
+
+                        continue;
+                } else if (streq(l, "cgroup-realized")) {
+                        int b;
+
+                        b = parse_boolean(v);
+                        if (b < 0)
+                                log_unit_debug(u->id, "Failed to parse cgroup-realized bool %s, ignoring.", v);
+                        else
+                                u->cgroup_realized = b;
 
                         continue;
                 }


### PR DESCRIPTION
Without the boolean bus_name_good services as well as cgroup_realized
for units a unit of Type=dbus and ExecReload sending SIGHUP to $MAINPID
will be terminated if systemd will be daemon reloaded.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=746151
https://bugs.freedesktop.org/show_bug.cgi?id=78311
https://bugzilla.opensuse.org/show_bug.cgi?id=934077

Cherry-picked from: de1d4f9b5c6345f63edd46f643485eca909995bf
Resolves: #1542391