### PR TITLE
(#1549119) timer: we already got the trigger before, no need to call UNIT_TRIGGE…

### DIFF
--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -421,7 +421,7 @@ static void timer_enter_waiting(Timer *t, bool initial) {
 
                         case TIMER_UNIT_INACTIVE:
 
-                                base = UNIT_TRIGGER(UNIT(t))->inactive_enter_timestamp.monotonic;
+                                base = trigger->inactive_enter_timestamp.monotonic;
 
                                 if (base <= 0)
                                         base = t->last_trigger.monotonic;


### PR DESCRIPTION
…R again

In d7b2f6ef we forgot to replace this occurence.

rhel-only

Resolves: #1549119