### PR TITLE
(#1552712) man/udevadm: correctly show the short version of --exit

### DIFF
--- a/man/udevadm.xml
+++ b/man/udevadm.xml
@@ -380,7 +380,7 @@
       <para>Modify the internal state of the running udev daemon.</para>
       <variablelist>
         <varlistentry>
-          <term><option>-x</option></term>
+          <term><option>-e</option></term>
           <term><option>--exit</option></term>
           <listitem>
             <para>Signal and wait for systemd-udevd to exit.</para>


### PR DESCRIPTION
Resolves: #1552712