### PR TITLE
core: introduce MemorySwapMax= (#1566177)

### DIFF
--- a/man/systemd.resource-control.xml
+++ b/man/systemd.resource-control.xml
@@ -200,6 +200,25 @@
       </varlistentry>
 
       <varlistentry>
+        <term><varname>MemorySwapMax=<replaceable>bytes</replaceable></varname></term>
+
+        <listitem>
+          <para>Specify the absolute limit on swap usage of the executed processes in this unit.</para>
+
+          <para>Takes a swap size in bytes. If the value is suffixed with K, M, G or T, the specified swap size is
+          parsed as Kilobytes, Megabytes, Gigabytes, or Terabytes (with the base 1024), respectively. If assigned the
+          special value <literal>infinity</literal>, no swap limit is applied. This controls the
+          <literal>memory.memsw.limit_in_bytes</literal> control group attribute. For details about this control group attribute,
+          see <ulink url="https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt">cgroup-v1/memory.txt</ulink>.</para>
+
+          <para>Implies <literal>MemoryAccounting=true</literal>.</para>
+
+          <para>Note that even though <literal>memory.memsw.limit_in_bytes</literal> is used, semantics of which is that the value
+          specifies memory limit plus the swap space, <literal>MemorySwapMax=</literal> specifies the absolute limit.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>TasksAccounting=</varname></term>
 
         <listitem>

--- a/src/core/cgroup.h
+++ b/src/core/cgroup.h
@@ -84,6 +84,7 @@ struct CGroupContext {
         LIST_HEAD(CGroupBlockIODeviceBandwidth, blockio_device_bandwidths);
 
         uint64_t memory_limit;
+        uint64_t memory_swap_max;
 
         CGroupDevicePolicy device_policy;
         LIST_HEAD(CGroupDeviceAllow, device_allow);

--- a/src/core/dbus-cgroup.c
+++ b/src/core/dbus-cgroup.c
@@ -148,6 +148,7 @@ const sd_bus_vtable bus_cgroup_vtable[] = {
         SD_BUS_PROPERTY("BlockIOWriteBandwidth", "a(st)", property_get_blockio_device_bandwidths, 0, 0),
         SD_BUS_PROPERTY("MemoryAccounting", "b", bus_property_get_bool, offsetof(CGroupContext, memory_accounting), 0),
         SD_BUS_PROPERTY("MemoryLimit", "t", NULL, offsetof(CGroupContext, memory_limit), 0),
+        SD_BUS_PROPERTY("MemorySwapMax", "t", NULL, offsetof(CGroupContext, memory_swap_max), 0),
         SD_BUS_PROPERTY("DevicePolicy", "s", property_get_cgroup_device_policy, offsetof(CGroupContext, device_policy), 0),
         SD_BUS_PROPERTY("DeviceAllow", "a(ss)", property_get_device_allow, 0, 0),
         SD_BUS_PROPERTY("TasksAccounting", "b", bus_property_get_bool, offsetof(CGroupContext, tasks_accounting), 0),
@@ -516,7 +517,7 @@ int bus_cgroup_set_property(
 
                 return 1;
 
-        } else if (streq(name, "MemoryLimit")) {
+        } else if (STR_IN_SET(name, "MemoryLimit", "MemorySwapMax")) {
                 uint64_t limit;
 
                 r = sd_bus_message_read(message, "t", &limit);
@@ -524,13 +525,20 @@ int bus_cgroup_set_property(
                         return r;
 
                 if (mode != UNIT_CHECK) {
-                        c->memory_limit = limit;
+                        if (streq(name, "MemoryLimit")) {
+                                c->memory_limit = limit;
+                                if (limit == (uint64_t) -1)
+                                        unit_write_drop_in_private(u, mode, name, "MemoryLimit=infinity");
+                                else
+                                        unit_write_drop_in_private_format(u, mode, name, "MemoryLimit=%" PRIu64, limit);
+                        } else if (streq(name, "MemorySwapMax")) {
+                                c->memory_swap_max = limit;
+                                if (limit == (uint64_t) -1)
+                                        unit_write_drop_in_private(u, mode, name, "MemorySwapMax=infinity");
+                                else
+                                        unit_write_drop_in_private_format(u, mode, name, "MemorySwapMax=%" PRIu64, limit);
+                        }
                         u->cgroup_realized_mask &= ~CGROUP_MEMORY;
-
-                        if (limit == (uint64_t) -1)
-                                unit_write_drop_in_private(u, mode, name, "MemoryLimit=infinity");
-                        else
-                                unit_write_drop_in_private_format(u, mode, name, "MemoryLimit=%" PRIu64, limit);
                 }
 
                 return 1;

--- a/src/core/load-fragment-gperf.gperf.m4
+++ b/src/core/load-fragment-gperf.gperf.m4
@@ -117,6 +117,7 @@ $1.StartupCPUShares,             config_parse_cpu_shares,            0,         
 $1.CPUQuota,                     config_parse_cpu_quota,             0,                             offsetof($1, cgroup_context)
 $1.MemoryAccounting,             config_parse_bool,                  0,                             offsetof($1, cgroup_context.memory_accounting)
 $1.MemoryLimit,                  config_parse_memory_limit,          0,                             offsetof($1, cgroup_context)
+$1.MemorySwapMax,                config_parse_memory_limit,          0,                             offsetof($1, cgroup_context)
 $1.DeviceAllow,                  config_parse_device_allow,          0,                             offsetof($1, cgroup_context)
 $1.DevicePolicy,                 config_parse_device_policy,         0,                             offsetof($1, cgroup_context.device_policy)
 $1.BlockIOAccounting,            config_parse_bool,                  0,                             offsetof($1, cgroup_context.blockio_accounting)

--- a/src/libsystemd/sd-bus/bus-util.c
+++ b/src/libsystemd/sd-bus/bus-util.c
@@ -1402,7 +1402,7 @@ int bus_append_unit_property_assignment(sd_bus_message *m, const char *assignmen
 
                 r = sd_bus_message_append(m, "v", "b", r);
 
-        } else if (streq(field, "MemoryLimit")) {
+        } else if (STR_IN_SET(field, "MemoryLimit", "MemorySwapMax")) {
                 off_t bytes;
 
                 r = parse_size(eq, 1024, &bytes);

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -3280,6 +3280,7 @@ typedef struct UnitStatusInfo {
         /* CGroup */
         uint64_t memory_current;
         uint64_t memory_limit;
+        uint64_t memory_swap_max;
         uint64_t tasks_current;
         uint64_t tasks_max;
 
@@ -3555,9 +3556,13 @@ static void print_status_info(
 
                 printf("   Memory: %s", format_bytes(buf, sizeof(buf), i->memory_current));
 
-                if (i->memory_limit != (uint64_t) -1)
-                        printf(" (limit: %s)\n", format_bytes(buf, sizeof(buf), i->memory_limit));
-                else
+                if (i->memory_limit != (uint64_t) -1) {
+                        printf(" (limit: %s", format_bytes(buf, sizeof(buf), i->memory_limit));
+                        if (i->memory_swap_max != (uint64_t) -1) {
+                                printf(", swap max: %s", format_bytes(buf, sizeof(buf), i->memory_swap_max));
+                        }
+                        printf(")\n");
+                } else
                         printf("\n");
         }
 
@@ -3779,6 +3784,8 @@ static int status_property(const char *name, sd_bus_message *m, UnitStatusInfo *
                         i->memory_current = u;
                 else if (streq(name, "MemoryLimit"))
                         i->memory_limit = u;
+                else if (streq(name, "MemorySwapMax"))
+                        i->memory_swap_max = u;
                 else if (streq(name, "TasksCurrent"))
                         i->tasks_current = u;
                 else if (streq(name, "TasksMax"))
@@ -4263,6 +4270,7 @@ static int show_one(
         UnitStatusInfo info = {
                 .memory_current = (uint64_t) -1,
                 .memory_limit = (uint64_t) -1,
+                .memory_swap_max = (uint64_t) -1,
                 .tasks_current = (uint64_t) -1,
                 .tasks_max = (uint64_t) -1,
         };


### PR DESCRIPTION
Similar to MemoryLimit=, MemorySwapMax= limits swap usage. This controls
controls "memory.memsw.limit_in_bytes" attribute in the cgroup hierarchy.

Resolves: #1566177

jsynacek: This still needs to be forward ported to upstream.