### PR TITLE
(#1573838) cryptsetup: support LUKS2 on-disk format

### DIFF
--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -36,7 +36,15 @@
 #include "libudev.h"
 #include "udev-util.h"
 
-static const char *arg_type = NULL; /* CRYPT_LUKS1, CRYPT_TCRYPT or CRYPT_PLAIN */
+/* libcryptsetup define for any LUKS version, compatible with libcryptsetup 1.x */
+#ifndef CRYPT_LUKS
+#define CRYPT_LUKS NULL
+#endif
+
+/* internal helper */
+#define ANY_LUKS "LUKS"
+
+static const char *arg_type = NULL; /* ANY_LUKS, CRYPT_LUKS1, CRYPT_LUKS2, CRYPT_TCRYPT or CRYPT_PLAIN */
 static char *arg_cipher = NULL;
 static unsigned arg_key_size = 0;
 static int arg_key_slot = CRYPT_ANY_SLOT;
@@ -98,7 +106,7 @@ static int parse_one_option(const char *option) {
 
         } else if (startswith(option, "key-slot=")) {
 
-                arg_type = CRYPT_LUKS1;
+                arg_type = ANY_LUKS;
                 if (safe_atoi(option+9, &arg_key_slot) < 0) {
                         log_error("key-slot= parse failure, ignoring.");
                         return 0;
@@ -138,7 +146,7 @@ static int parse_one_option(const char *option) {
                 arg_hash = t;
 
         } else if (startswith(option, "header=")) {
-                arg_type = CRYPT_LUKS1;
+                arg_type = ANY_LUKS;
 
                 if (!path_is_absolute(option+7)) {
                         log_error("Header path '%s' is not absolute, refusing.", option+7);
@@ -168,7 +176,7 @@ static int parse_one_option(const char *option) {
         else if (STR_IN_SET(option, "allow-discards", "discard"))
                 arg_discards = true;
         else if (streq(option, "luks"))
-                arg_type = CRYPT_LUKS1;
+                arg_type = ANY_LUKS;
         else if (streq(option, "tcrypt"))
                 arg_type = CRYPT_TCRYPT;
         else if (streq(option, "tcrypt-hidden")) {
@@ -430,8 +438,8 @@ static int attach_luks_or_plain(struct crypt_device *cd,
         assert(name);
         assert(key_file || passwords);
 
-        if (!arg_type || streq(arg_type, CRYPT_LUKS1)) {
-                r = crypt_load(cd, CRYPT_LUKS1, NULL);
+        if (!arg_type || STR_IN_SET(arg_type, ANY_LUKS, CRYPT_LUKS1)) {
+                r = crypt_load(cd, CRYPT_LUKS, NULL);
                 if (r < 0) {
                         log_error("crypt_load() failed on device %s.\n", crypt_get_device_name(cd));
                         return r;


### PR DESCRIPTION
Allow cryptsetup utility to activate LUKS2 devices (with appropriate
libcryptsetup)

The change itself doesn't enforce new libcryptsetup 2.x and is backward
compatible with versions 1.x

(cherry-picked from commit b3b4ebab02395933cde554b5a5d5c363dae3920d)

Resolves: #1573838