### PR TITLE
(#1587906) core/timer: downgrade message about random time addition

### DIFF
--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -335,7 +335,7 @@ static void add_random(Timer *t, usec_t *v) {
         else
                 *v += add;
 
-        log_unit_info(UNIT(t)->id, "Adding %s random time.", format_timespan(s, sizeof(s), add, 0));
+        log_unit_debug(UNIT(t)->id, "Adding %s random time.", format_timespan(s, sizeof(s), add, 0));
 }
 
 static void timer_enter_waiting(Timer *t, bool initial) {


### PR DESCRIPTION
This seems like something that shouldn't be higher then debug level, even
if it does not get emitted too often.

Fixes #5228.

(cherry picked from commit 382852fd581efe3cc0ae11154102ab9f435adea1)
Resolves: #1587906