### PR TITLE
(#1247963) journal: fix HMAC calculation when appending a data object

### DIFF
--- a/src/journal/journal-file.c
+++ b/src/journal/journal-file.c
@@ -1099,6 +1099,12 @@ static int journal_file_append_data(
         if (r < 0)
                 return r;
 
+#ifdef HAVE_GCRYPT
+        r = journal_file_hmac_put_object(f, OBJECT_DATA, o, p);
+        if (r < 0)
+                return r;
+#endif
+
         /* The linking might have altered the window, so let's
          * refresh our pointer */
         r = journal_file_move_to_object(f, OBJECT_DATA, p, &o);
@@ -1122,12 +1128,6 @@ static int journal_file_append_data(
                 o->data.next_field_offset = fo->field.head_data_offset;
                 fo->field.head_data_offset = le64toh(p);
         }
-
-#ifdef HAVE_GCRYPT
-        r = journal_file_hmac_put_object(f, OBJECT_DATA, o, p);
-        if (r < 0)
-                return r;
-#endif
 
         if (ret)
                 *ret = o;


### PR DESCRIPTION
Since commit 5996c7c295e073ce21d41305169132c8aa993ad0 (v190 !), the
calculation of the HMAC is broken because the hash for a data object
including a field is done in the wrong order: the field object is
hashed before the data object is.

However during verification, the hash is done in the opposite order as
objects are scanned sequentially.

(cherry picked from commit 33685a5a3a98c6ded64d0cc25e37d0180ceb0a6a)