### PR TITLE
core: delay adding target dependencies until all units are loaded and aliases resolved (#1368856)

### DIFF
--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -114,6 +114,9 @@ struct Manager {
         /* Units that should be realized */
         LIST_HEAD(Unit, cgroup_queue);
 
+        /* Target units whose default target dependencies haven't been set yet */
+        LIST_HEAD(Unit, target_deps_queue);
+
         sd_event *event;
 
         /* We use two hash tables here, since the same PID might be

--- a/src/core/unit.h
+++ b/src/core/unit.h
@@ -162,6 +162,9 @@ struct Unit {
         /* CGroup realize members queue */
         LIST_FIELDS(Unit, cgroup_queue);
 
+        /* Target dependencies queue */
+        LIST_FIELDS(Unit, target_deps_queue);
+
         /* PIDs we keep an eye on. Note that a unit might have many
          * more, but these are the ones we care enough about to
          * process SIGCHLD for */
@@ -228,6 +231,7 @@ struct Unit {
         bool in_cleanup_queue:1;
         bool in_gc_queue:1;
         bool in_cgroup_queue:1;
+        bool in_target_deps_queue:1;
 
         bool sent_dbus_new_signal:1;
 
@@ -498,6 +502,7 @@ void unit_add_to_load_queue(Unit *u);
 void unit_add_to_dbus_queue(Unit *u);
 void unit_add_to_cleanup_queue(Unit *u);
 void unit_add_to_gc_queue(Unit *u);
+void unit_add_to_target_deps_queue(Unit *u);
 
 int unit_merge(Unit *u, Unit *other);
 int unit_merge_by_name(Unit *u, const char *other);


### PR DESCRIPTION
Currently we add target dependencies while we are loading units. This
can create ordering loops even if configuration doesn't contain any
loop. Take for example following configuration,

$ systemctl get-default
multi-user.target

$ cat /etc/systemd/system/test.service
[Unit]
After=default.target

[Service]
ExecStart=/bin/true

[Install]
WantedBy=multi-user.target

If we encounter such unit file early during manager start-up (e.g. load
queue is dispatched while enumerating devices due to SYSTEMD_WANTS in
udev rules) we would add stub unit default.target and we order it Before
test.service. At the same time we add implicit Before to
multi-user.target. Later we merge two units and we create ordering cycle
in the process.

To fix the issue we will now never add any target dependencies until we
loaded all the unit files and resolved all the aliases.

(cherry picked from commit 19496554e23ea4861ce780430052dcf86a2ffcba)

Resolves: #1368856