### PR TITLE
(#1582383) rpm: fix %systemd_user_post() macro.

### DIFF
--- a/src/core/macros.systemd.in
+++ b/src/core/macros.systemd.in
@@ -43,7 +43,7 @@ if [ $1 -eq 1 ] ; then \
 fi \
 %{nil}
 
-%systemd_user_post() %systemd_post --user --global %{?*}
+%systemd_user_post() %{expand:%systemd_post \\--user \\--global %%{?*}}
 
 %systemd_preun() \
 if [ $1 -eq 0 ] ; then \

--- a/src/core/macros.systemd.in
+++ b/src/core/macros.systemd.in
@@ -43,7 +43,7 @@ if [ $1 -eq 1 ] ; then \
 fi \
 %{nil}
 
-%systemd_user_post() %{expand:%systemd_post \\--user \\--global %%{?*}}
+%systemd_user_post() %{expand:%systemd_post \\--global %%{?*}}
 
 %systemd_preun() \
 if [ $1 -eq 0 ] ; then \
@@ -56,7 +56,7 @@ fi \
 %systemd_user_preun() \
 if [ $1 -eq 0 ] ; then \
         # Package removal, not upgrade \
-        systemctl --no-reload --user --global disable %{?*} > /dev/null 2>&1 || : \
+        systemctl --global disable %{?*} > /dev/null 2>&1 || : \
 fi \
 %{nil}
 


### PR DESCRIPTION
Escape "--user" and "--global" arguments with "\\" since rpm treats
arguments starting with "-" as macro options which causes "Unknown
option" rpm error.
Use %{expand:...} to force expansion of the inner macro. Otherwise %{?*}
is recursively defined as "\--user \--global {%?*}" which causes
"Too many levels of recursion in macro expansion" rpm error.

Thanks to Michael Mráka for helping me fix the above issues.

(cherry picked from commit e67ba783696f21782ad5c2ba00515d387016e785)
Resolves: #1582383