### PR TITLE
(#1601794) man: document that SIGCONT always follows SIGTERM

### DIFF
--- a/man/systemd.kill.xml
+++ b/man/systemd.kill.xml
@@ -136,7 +136,13 @@
         by <constant>SIGKILL</constant> (see above and below). For a
         list of valid signals, see
         <citerefentry project='man-pages'><refentrytitle>signal</refentrytitle><manvolnum>7</manvolnum></citerefentry>.
-        Defaults to <constant>SIGTERM</constant>. </para></listitem>
+        Defaults to <constant>SIGTERM</constant>. </para>
+
+        <para>Note that right after sending the signal specified in
+        this setting systemd will always send
+        <constant>SIGCONT</constant>, to ensure that even suspended
+        tasks can be terminated cleanly.</para>
+        </listitem>
       </varlistentry>
 
       <varlistentry>


### PR DESCRIPTION
As requested in #199.

(cherry picked from commit e8c53936316288ea3b33b5997b175862f0efef92)
Resolves: #1601794