### PR TITLE
rules: mark hotplugged memory as movable (#1563532)

### DIFF
--- a/rules/40-redhat.rules
+++ b/rules/40-redhat.rules
@@ -4,7 +4,7 @@
 SUBSYSTEM=="cpu", ACTION=="add", TEST=="online", ATTR{online}=="0", ATTR{online}="1"
 
 # Memory hotadd request
-SUBSYSTEM=="memory", ACTION=="add", PROGRAM="/bin/uname -p", RESULT!="s390*", ATTR{state}=="offline", ATTR{state}="online"
+SUBSYSTEM=="memory", ACTION=="add", PROGRAM="/bin/uname -p", RESULT!="s390*", ATTR{state}=="offline", ATTR{state}="online_movable"
 
 # reload sysctl.conf / sysctl.conf.d settings when the bridge module is loaded
 ACTION=="add", SUBSYSTEM=="module", KERNEL=="bridge", RUN+="/usr/lib/systemd/systemd-sysctl --prefix=/proc/sys/net/bridge"


### PR DESCRIPTION
Otherwise the kernel is free to use to memory block also for storing
non-movable memory (any other memory except anonymous memory allocations
and page cache). If user later wants to hot unplug the memory the kernel
will return error in case that some non-movable memory has been place to
the memory block.

Marking hot plugged memory blocks as movable seems to be better
default. Users with specific needs are free to override this udev rule.

Resolves: #1563532