### PR TITLE
(#1631625) shorten hostname before checking for trailing dot

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -4641,6 +4641,8 @@ char* hostname_cleanup(char *s, bool lowercase) {
         char *p, *d;
         bool dot;
 
+        strshorten(s, HOST_NAME_MAX);
+
         for (p = s, d = s, dot = true; *p; p++) {
                 if (*p == '.') {
                         if (dot)
@@ -4659,8 +4661,6 @@ char* hostname_cleanup(char *s, bool lowercase) {
                 d[-1] = 0;
         else
                 *d = 0;
-
-        strshorten(s, HOST_NAME_MAX);
 
         return s;
 }


### PR DESCRIPTION
Shortening can lead to a hostname that has a trailing dot.
Therefore it should be done before checking from trailing dots.

(cherry picked from commit 46e1a2278116e2f5067c35127ccbd8589335f734)
Resolves: #1631625