### PR TITLE
(#1641581) dhcp6: make sure we have enough space for the DHCP6 option header

### DIFF
--- a/src/libsystemd-network/dhcp6-option.c
+++ b/src/libsystemd-network/dhcp6-option.c
@@ -100,7 +100,7 @@ int dhcp6_option_append_ia(uint8_t **buf, size_t *buflen, DHCP6IA *ia) {
                 return -EINVAL;
         }
 
-        if (*buflen < len)
+        if (*buflen < offsetof(DHCP6Option, data) + len)
                 return -ENOBUFS;
 
         ia_hdr = *buf;


### PR DESCRIPTION
Fixes a vulnerability originally discovered by Felix Wilhelm from Google.

(cherry picked from commit 01ca2053bbea09f35b958c8cc7631e15469acb79)

Resolves: CVE-2018-15688