### PR TITLE
(#1641566) core: when deserializing state always use read_line(…, LONG_LINE_MAX, …)

### DIFF
--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -37,6 +37,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <sys/timerfd.h>
+#include <fileio.h>
 
 #ifdef HAVE_AUDIT
 #include <libaudit.h>
@@ -2559,21 +2560,19 @@ int manager_deserialize(Manager *m, FILE *f, FDSet *fds) {
         m->n_reloading ++;
 
         for (;;) {
-                char line[LINE_MAX], *l;
+                _cleanup_free_ char *line = NULL;
+                char *l;
 
-                if (!fgets(line, sizeof(line), f)) {
-                        if (feof(f))
-                                r = 0;
-                        else
-                                r = -errno;
 
-                        goto finish;
-                }
+                r = read_line(f, LONG_LINE_MAX, &line);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to read serialization line: %m");
+                if (r == 0)
+                        break;
 
-                char_array_0(line);
                 l = strstrip(line);
 
-                if (l[0] == 0)
+                 if (isempty(l)) /* end marker */
                         break;
 
                 if (startswith(l, "current-job-id=")) {
@@ -2708,22 +2707,17 @@ int manager_deserialize(Manager *m, FILE *f, FDSet *fds) {
         }
 
         for (;;) {
+                _cleanup_free_ char *line = NULL;
                 Unit *u;
-                char name[UNIT_NAME_MAX+2];
 
                 /* Start marker */
-                if (!fgets(name, sizeof(name), f)) {
-                        if (feof(f))
-                                r = 0;
-                        else
-                                r = -errno;
+                r = read_line(f, LONG_LINE_MAX, &line);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to read serialization line: %m");
+                if (r == 0)
+                        break;
 
-                        goto finish;
-                }
-
-                char_array_0(name);
-
-                r = manager_load_unit(m, strstrip(name), NULL, NULL, &u);
+                r = manager_load_unit(m, strstrip(line), NULL, NULL, &u);
                 if (r < 0)
                         goto finish;
 

--- a/src/core/service.c
+++ b/src/core/service.c
@@ -3039,8 +3039,12 @@ static void service_notify_message(Unit *u, pid_t pid, char **tags, FDSet *fds) 
                 _cleanup_free_ char *t = NULL;
 
                 if (!isempty(e)) {
-                        if (!utf8_is_valid(e))
-                                log_unit_warning(u->id, "Status message in notification is not UTF-8 clean.");
+                        /* Note that this size limit check is mostly paranoia: since the datagram size we are willing
+                         * to process is already limited to NOTIFY_BUFFER_MAX, this limit here should never be hit. */
+                        if (strlen(e) > STATUS_TEXT_MAX)
+                                log_unit_warning(u->id, "Status message overly long (%zu > %u), ignoring.", strlen(e), STATUS_TEXT_MAX);
+                        else if (!utf8_is_valid(e))
+                                log_unit_warning(u->id, "Status message in notification message is not UTF-8 clean, ignoring.");
                         else {
                                 log_unit_debug(u->id, "%s: got STATUS=%s", u->id, e);
 

--- a/src/core/service.h
+++ b/src/core/service.h
@@ -31,6 +31,8 @@ typedef struct ServiceFDStore ServiceFDStore;
 #include "exit-status.h"
 #include "emergency-action.h"
 
+#define STATUS_TEXT_MAX (16U*1024U)
+
 typedef enum ServiceState {
         SERVICE_DEAD,
         SERVICE_START_PRE,

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -2644,20 +2644,19 @@ int unit_deserialize(Unit *u, FILE *f, FDSet *fds) {
                 rt = (ExecRuntime**) ((uint8_t*) u + offset);
 
         for (;;) {
-                char line[LINE_MAX], *l, *v;
+                 _cleanup_free_ char *line = NULL;
+                char *l, *v;
                 size_t k;
 
-                if (!fgets(line, sizeof(line), f)) {
-                        if (feof(f))
-                                return 0;
-                        return -errno;
-                }
+                r = read_line(f, LONG_LINE_MAX, &line);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to read serialization line: %m");
+                if (r == 0) /* eof */
+                        return 0;
 
-                char_array_0(line);
                 l = strstrip(line);
-
                 /* End marker */
-                if (l[0] == 0)
+                if (isempty(l))
                         return 0;
 
                 k = strcspn(l, "=");


### PR DESCRIPTION
This should be much better than fgets(), as we can read substantially
longer lines and overly long lines result in proper errors.

Fixes a vulnerability discovered by Jann Horn at Google.

(cherry picked from commit 8948b3415d762245ebf5e19d80b97d4d8cc208c1)

Resolves: CVE-2018-15686

[jsynacek] There were more commits in the pull request of which the cherry
picked commit was a part of, see
https://github.com/systemd/systemd/pull/10519/commits.
I decided not to backport any of the remaining ones, because they were
mostly irrelevant to the actual fix.