### PR TITLE
Revert "sysctl.d: request ECN on both in and outgoing connections" (#1619790)

### DIFF
--- a/sysctl.d/50-default.conf
+++ b/sysctl.d/50-default.conf
@@ -33,9 +33,6 @@ net.ipv4.conf.all.promote_secondaries = 1
 # Fair Queue CoDel packet scheduler to fight bufferbloat
 net.core.default_qdisc = fq_codel
 
-# Request Explicit Congestion Notification (ECN) on both in and outgoing connections
-net.ipv4.tcp_ecn = 1
-
 # Enable hard and soft link protection
 fs.protected_hardlinks = 1
 fs.protected_symlinks = 1


### PR DESCRIPTION
Turning on ECN still causes slow or broken network on linux. Our tcp
is not yet ready for wide spread use of ECN.

This reverts commit 919472741dba6ad0a3f6c2b76d390a02d0e2fdc3.

(cherry picked from commit 1e190dfd5bb95036f937ef1dc46f43eb0a146612)

Resolves: #1619790