### PR TITLE
dhcp6: make sure we have enough space for the DHCP6 option header (#1643363)

### DIFF
--- a/src/libsystemd-network/dhcp6-option.c
+++ b/src/libsystemd-network/dhcp6-option.c
@@ -103,7 +103,7 @@ int dhcp6_option_append_ia(uint8_t **buf, size_t *buflen, DHCP6IA *ia) {
                 return -EINVAL;
         }
 
-        if (*buflen < len)
+        if (*buflen < offsetof(DHCP6Option, data) + len)
                 return -ENOBUFS;
 
         ia_hdr = *buf;


### PR DESCRIPTION
Fixes a vulnerability originally discovered by Felix Wilhelm from
Google.

CVE-2018-15688
LP: #1795921
https://bugzilla.redhat.com/show_bug.cgi?id=1639067

(cherry-picked from commit 4dac5eaba4e419b29c97da38a8b1f82336c2c892)

Resolves: #1643363