### PR TITLE
(#1638676) rules: watch metadata changes on DASD devices

### DIFF
--- a/rules/60-block.rules
+++ b/rules/60-block.rules
@@ -8,4 +8,4 @@ ACTION=="add", SUBSYSTEM=="module", KERNEL=="block", ATTR{parameters/events_dfl_
 ACTION=="change", SUBSYSTEM=="scsi", ENV{DEVTYPE}=="scsi_device", TEST=="block", ATTR{block/*/uevent}="change"
 
 # watch metadata changes, caused by tools closing the device node which was opened for writing
-ACTION!="remove", SUBSYSTEM=="block", KERNEL=="loop*|nvme*|sd*|vd*|xvd*|pmem*|mmcblk*", OPTIONS+="watch"
+ACTION!="remove", SUBSYSTEM=="block", KERNEL=="loop*|nvme*|sd*|vd*|xvd*|pmem*|mmcblk*|dasd*", OPTIONS+="watch"


### PR DESCRIPTION
To make sure the change event is emitted and udev db is updated
after metadata changes.

(cherry picked from commit 38397c8ce044fdc0138c9919168a856c0e16f720)

Resolves: #1638676