### PR TITLE
(#1649518) systemctl: Allow 'edit' and 'cat' on unloaded units

### DIFF
--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -2311,41 +2311,11 @@ static int unit_find_paths(sd_bus *bus,
 
         if (!avoid_bus_cache && !unit_name_is_template(unit_name)) {
                 _cleanup_bus_error_free_ sd_bus_error error = SD_BUS_ERROR_NULL;
-                _cleanup_bus_message_unref_ sd_bus_message *unit_load_error = NULL;
                 _cleanup_free_ char *unit = NULL;
-                char *unit_load_error_name, *unit_load_error_message;
 
                 unit = unit_dbus_path_from_name(unit_name);
                 if (!unit)
                         return log_oom();
-
-                if (need_daemon_reload(bus, unit_name) > 0)
-                        warn_unit_file_changed(unit_name);
-
-                r = sd_bus_get_property(
-                                bus,
-                                "org.freedesktop.systemd1",
-                                unit,
-                                "org.freedesktop.systemd1.Unit",
-                                "LoadError",
-                                &error,
-                                &unit_load_error,
-                                "(ss)");
-                if (r < 0)
-                        return log_error_errno(r, "Failed to get LoadError: %s", bus_error_message(&error, r));
-
-                r = sd_bus_message_read(
-                                unit_load_error,
-                                "(ss)",
-                                &unit_load_error_name,
-                                &unit_load_error_message);
-                if (r < 0)
-                        return bus_log_parse_error(r);
-
-                if (!isempty(unit_load_error_name)) {
-                        log_error("Unit %s is not loaded: %s", unit_name, unit_load_error_message);
-                        return 0;
-                }
 
                 r = sd_bus_get_property_string(
                                 bus,


### PR DESCRIPTION
Don't fail if the unit has a LoadError; otherwise `systemctl edit` cannot be
used to correct the error (e.g. multiple "ExecStart=" lines).

Remove file changed warning so cat output isn't interspersed with log messages.

Fixes #829

(cherry picked from commit 1e524ec6e2031629fec27906423619e3403b2f3e)

Resolves: #1649518