### PR TITLE
(#1653824) sysctl.d: switch net.ipv4.conf.all.rp_filter from 1 to 2

### DIFF
--- a/sysctl.d/50-default.conf
+++ b/sysctl.d/50-default.conf
@@ -22,7 +22,7 @@ kernel.sysrq = 16
 kernel.core_uses_pid = 1
 
 # Source route verification
-net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.all.rp_filter = 2
 
 # Do not accept source routing
 net.ipv4.conf.all.accept_source_route = 0


### PR DESCRIPTION
This switches the RFC3704 Reverse Path filtering from Strict mode to Loose
mode. The Strict mode breaks some pretty common and reasonable use cases,
such as keeping connections via one default route alive after another one
appears (e.g. plugging an Ethernet cable when connected via Wi-Fi).

The strict filter also makes it impossible for NetworkManager to do
connectivity check on a newly arriving default route (it starts with a
higher metric and is bumped lower if there's connectivity).

Kernel's default is 0 (no filter), but a Loose filter is good enough. The
few use cases where a Strict mode could make sense can easily override
this.

The distributions that don't care about the client use cases and prefer a
strict filter could just ship a custom configuration in
/usr/lib/sysctl.d/ to override this.

Cherry-picked from: 230450d4e4f1f5fc9fa4295ed9185eea5b6ea16e
Resolves: #1653824