### PR TITLE
(#1585411) core: mount-setup: handle non-existing mountpoints gracefully

### DIFF
--- a/src/core/mount-setup.c
+++ b/src/core/mount-setup.c
@@ -163,6 +163,9 @@ static int mount_one(const MountPoint *p, bool relabel) {
                 label_fix(p->where, true, true);
 
         r = path_is_mount_point(p->where, true);
+        if (r == -ENOENT)
+                return 0;
+
         if (r < 0)
                 return r;
 


### PR DESCRIPTION
Commit e792e890f ("path-util: don't eat up ENOENT in
path_is_mount_point()") changed path_is_mount_point() so it doesn't hide
-ENOENT from its caller. This causes all boots to fail early in case
any of the mount points does not exist (for instance, when kdbus isn't
loaded, /sys/fs/kdbus is missing).

Fix this by returning 0 from mount_one() if path_is_mount_point()
returned -ENOENT.

(cherry picked from commit b604cb9bf6a14d12589e85b82f3f59db93ea0029)

Resolves: #1585411