### PR TITLE
meson: various fixes for CentOS CI

### DIFF
--- a/README
+++ b/README
@@ -154,6 +154,7 @@ REQUIREMENTS:
         libmicrohttpd (optional)
         libpython (optional)
         libidn2 or libidn (optional)
+        gnutls >= 3.1.4 (optional, >= 3.5.3 is necessary to support DNS-over-TLS)
         elfutils >= 158 (optional)
         polkit (optional)
         pkg-config

--- a/meson.build
+++ b/meson.build
@@ -769,7 +769,7 @@ substs.set('DEBUGTTY', get_option('debug-tty'))
 
 enable_debug_hashmap = false
 enable_debug_mmap_cache = false
-foreach name : get_option('debug')
+foreach name : get_option('debug-extra')
         if name == 'hashmap'
                 enable_debug_hashmap = true
         elif name == 'mmap-cache'

--- a/meson.build
+++ b/meson.build
@@ -1148,7 +1148,7 @@ substs.set('DEFAULT_DNSSEC_MODE', default_dnssec)
 
 dns_over_tls = get_option('dns-over-tls')
 if dns_over_tls != 'false'
-        have = conf.get('HAVE_GNUTLS') == 1
+        have = libgnutls != [] and libgnutls.version().version_compare('>=3.5.3')
         if dns_over_tls == 'true' and not have
                 error('DNS-over-TLS support was requested, but dependencies are not available')
         endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -46,7 +46,7 @@ option('debug-shell', type : 'string', value : '/bin/sh',
        description : 'path to debug shell binary')
 option('debug-tty', type : 'string', value : '/dev/tty9',
        description : 'specify the tty device for debug shell')
-option('debug', type : 'array', choices : ['hashmap', 'mmap-cache'], value : [],
+option('debug-extra', type : 'array', choices : ['hashmap', 'mmap-cache'], value : [],
        description : 'enable extra debugging')
 option('memory-accounting-default', type : 'boolean',
        description : 'enable MemoryAccounting= by default')


### PR DESCRIPTION
This PR contains several meson-related fixes to support building of the RHEL8 systemd in CentOS CI (CentOS 7), as we already do in upstream.