### PR TITLE
test-functions: fix dbus-1 installation

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -271,7 +271,7 @@ install_dbus() {
     inst $ROOTLIBDIR/system/dbus.service
 
     find \
-        /etc/dbus-1 -xtype f \
+        /etc/dbus-1 /usr/share/dbus-1 -xtype f \
         | while read file; do
         inst $file
     done


### PR DESCRIPTION
The basic setup for the well-known system and session buses is
now done in read-only files in ${datadir} (normally /usr/share).
See the NEWS entry for 1.9.18 for details.

http://cgit.freedesktop.org/dbus/dbus/tree/NEWS

Cherry-picked from: e63b61be5350dbe92ea12e1eeb96dde251ed9292

---
This should finally fix the integration testsuite (`test/TEST-??-*`) on RHEL 7.

cc @msekletar 