### PR TITLE
test: Drop SKIP_INITRD for QEMU-based tests

### DIFF
--- a/test/TEST-08-ISSUE-2730/test.sh
+++ b/test/TEST-08-ISSUE-2730/test.sh
@@ -6,7 +6,6 @@ TEST_DESCRIPTION="https://github.com/systemd/systemd/issues/2730"
 TEST_NO_NSPAWN=1
 
 . $TEST_BASE_DIR/test-functions
-SKIP_INITRD=yes
 QEMU_TIMEOUT=180
 FSTYPE=ext4
 

--- a/test/TEST-09-ISSUE-2691/test.sh
+++ b/test/TEST-09-ISSUE-2691/test.sh
@@ -6,7 +6,6 @@ TEST_DESCRIPTION="https://github.com/systemd/systemd/issues/2691"
 TEST_NO_NSPAWN=1
 
 . $TEST_BASE_DIR/test-functions
-SKIP_INITRD=yes
 QEMU_TIMEOUT=90
 
 test_setup() {

--- a/test/TEST-10-ISSUE-2467/test.sh
+++ b/test/TEST-10-ISSUE-2467/test.sh
@@ -5,7 +5,6 @@ set -e
 TEST_DESCRIPTION="https://github.com/systemd/systemd/issues/2467"
 
 . $TEST_BASE_DIR/test-functions
-SKIP_INITRD=yes
 
 test_setup() {
     create_empty_image

--- a/test/TEST-11-ISSUE-3166/test.sh
+++ b/test/TEST-11-ISSUE-3166/test.sh
@@ -6,7 +6,6 @@ TEST_DESCRIPTION="https://github.com/systemd/systemd/issues/3166"
 TEST_NO_NSPAWN=1
 
 . $TEST_BASE_DIR/test-functions
-SKIP_INITRD=yes
 
 test_setup() {
     create_empty_image

--- a/test/TEST-13-NSPAWN-SMOKE/test.sh
+++ b/test/TEST-13-NSPAWN-SMOKE/test.sh
@@ -4,7 +4,7 @@
 set -e
 TEST_DESCRIPTION="systemd-nspawn smoke test"
 TEST_NO_NSPAWN=1
-SKIP_INITRD=yes
+
 . $TEST_BASE_DIR/test-functions
 
 test_setup() {

--- a/test/TEST-14-MACHINE-ID/test.sh
+++ b/test/TEST-14-MACHINE-ID/test.sh
@@ -4,7 +4,7 @@
 set -e
 TEST_DESCRIPTION="/etc/machine-id testing"
 TEST_NO_NSPAWN=1
-SKIP_INITRD=yes
+
 . $TEST_BASE_DIR/test-functions
 
 test_setup() {


### PR DESCRIPTION
Not all distros support booting without an initrd. E.g. the Debian
kernel builds ext4 as a module and so relies on an initrd to
successfully start the QEMU-based images.

Cherry-picked from: c2d4da002095fe6f86f89a508a81e48fb6d3196f

---

`SKIP_INITRD` effectively breaks all QEMU tests on RHEL/CentOS, as the `ext4` filesystem is shipped as module and needs to be explicitly included in the custom initrd.