### PR TITLE
Various fixes for Travis on RHEL 7

### DIFF
--- a/src/shared/copy.c
+++ b/src/shared/copy.c
@@ -271,13 +271,12 @@ static int fd_copy_directory(
                         continue;
                 }
 
-                if (buf.st_dev != original_device)
-                        continue;
-
-                if (S_ISREG(buf.st_mode))
-                        q = fd_copy_regular(dirfd(d), de->d_name, &buf, fdt, de->d_name);
-                else if (S_ISDIR(buf.st_mode))
+                if (S_ISDIR(buf.st_mode)) {
+                        if (buf.st_dev != original_device)
+                                continue;
                         q = fd_copy_directory(dirfd(d), de->d_name, &buf, fdt, de->d_name, original_device, merge);
+                } else if (S_ISREG(buf.st_mode))
+                        q = fd_copy_regular(dirfd(d), de->d_name, &buf, fdt, de->d_name);
                 else if (S_ISLNK(buf.st_mode))
                         q = fd_copy_symlink(dirfd(d), de->d_name, &buf, fdt, de->d_name);
                 else if (S_ISFIFO(buf.st_mode))

--- a/src/shared/path-util.c
+++ b/src/shared/path-util.c
@@ -484,7 +484,7 @@ static int fd_fdinfo_mnt_id(int fd, const char *filename, int flags, int *mnt_id
         if ((flags & AT_EMPTY_PATH) && isempty(filename))
                 xsprintf(path, "/proc/self/fdinfo/%i", fd);
         else {
-                subfd = openat(fd, filename, O_CLOEXEC|O_PATH);
+                subfd = openat(fd, filename, O_CLOEXEC|O_PATH|(flags & AT_SYMLINK_FOLLOW ? 0 : O_NOFOLLOW));
                 if (subfd < 0)
                         return -errno;
 

--- a/src/test/test-capability.c
+++ b/src/test/test-capability.c
@@ -160,8 +160,6 @@ static void test_update_inherited_set(void) {
 
         caps = cap_get_proc();
         assert_se(caps);
-        assert_se(!cap_get_flag(caps, CAP_CHOWN, CAP_INHERITABLE, &fv));
-        assert(fv == CAP_CLEAR);
 
         set = (UINT64_C(1) << CAP_CHOWN);
 
@@ -176,12 +174,6 @@ static void test_set_ambient_caps(void) {
         cap_t caps;
         uint64_t set = 0;
         cap_flag_value_t fv;
-
-        caps = cap_get_proc();
-        assert_se(caps);
-        assert_se(!cap_get_flag(caps, CAP_CHOWN, CAP_INHERITABLE, &fv));
-        assert(fv == CAP_CLEAR);
-        cap_free(caps);
 
         assert_se(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_CHOWN, 0, 0) == 0);
 


### PR DESCRIPTION
Several backports from upstream to support RHEL 7 systemd in Travis (CentOS 7 Docker container).

1) https://github.com/systemd/systemd/commit/c446b8486d9ed18d1bc780948ae9ee8a53fa4c3f
Test-only change.
Original issue: https://github.com/systemd/systemd/issues/10663
Original PR: https://github.com/systemd/systemd/pull/10687

2) https://github.com/systemd/systemd/commit/be24321f3dae91a166166b239954032727439942
Original issue: https://github.com/systemd/systemd/issues/11092
Original PR: https://github.com/systemd/systemd/pull/11094

3) https://github.com/systemd/systemd/commit/ef202b848bb6635dec17d3ec0041b04cd2301bed
The original PR contains two more commits and I'm not sure if it's worth backporting them as well, opinions are welcome.
Original PR: https://github.com/systemd/systemd/pull/9213/

There's still one outstanding issue breaking the Travis CI, see https://github.com/lnykryn/systemd-rhel/pull/259#issuecomment-452264876.