### PR TITLE
travis: Fix dbus timeout on RHEL/CentOS 7

### DIFF
--- a/ci/travis-centos-rhel7.sh
+++ b/ci/travis-centos-rhel7.sh
@@ -60,6 +60,10 @@ for phase in "${PHASES[@]}"; do
             $DOCKER_EXEC sed -i '/test_path_changed,/d' src/test/test-path.c
 
             # Run the internal testsuite
+            # Let's install the new systemd and "reboot" the container to avoid
+            # unexpected fails due to incompatibilities with older systemd
+            $DOCKER_EXEC make install
+            docker restart $CONT_NAME
             if ! $DOCKER_EXEC make check; then
                 $DOCKER_EXEC cat test-suite.log
                 exit 1

--- a/ci/travis-centos-rhel7.sh
+++ b/ci/travis-centos-rhel7.sh
@@ -52,13 +52,6 @@ for phase in "${PHASES[@]}"; do
                                      --enable-gtk-doc --enable-compat-libs --disable-sysusers \
                                      --disable-ldconfig --enable-lz4 --with-sysvinit-path=/etc/rc.d/init.d
             $DOCKER_EXEC make
-            # Temporarily skip test_path_changed in src/test/test-path.c
-            # This particular test case timeouts on Ubuntu in a Docker image
-            # and needs further debugging (couldn't reproduce it on
-            # Fedora + Docker
-            $DOCKER_EXEC sed -i '/static void test_path_changed/,/^}\s*$/d' src/test/test-path.c
-            $DOCKER_EXEC sed -i '/test_path_changed,/d' src/test/test-path.c
-
             # Run the internal testsuite
             # Let's install the new systemd and "reboot" the container to avoid
             # unexpected fails due to incompatibilities with older systemd

--- a/ci/travis-centos-rhel8.sh
+++ b/ci/travis-centos-rhel8.sh
@@ -113,6 +113,10 @@ for phase in "${PHASES[@]}"; do
             )
             docker exec -it -e CFLAGS='-g -O0 -ftrapv' $CONT_NAME meson build "${CONFIGURE_OPTS[@]}"
             $DOCKER_EXEC ninja -v -C build
+            # Let's install the new systemd and "reboot" the container to avoid
+            # unexpected fails due to incompatibilities with older systemd
+            $DOCKER_EXEC ninja -C build install
+            docker restart $CONT_NAME
             # "Mask" the udev-test.pl, as it requires newer version of systemd-detect-virt
             # and it's pointless to run it on a VM in a Docker container...
             echo -ne "#!/usr/bin/perl\nexit(0);\n" > "test/udev-test.pl"


### PR DESCRIPTION
This should fix the last timeouting test (test_path_changed) on RHEL/CentOS 7.