### PR TITLE
(#1666612) rules: fix memory hotplug rule so systemd-detect-virt does not run too often

### DIFF
--- a/rules/40-redhat.rules
+++ b/rules/40-redhat.rules
@@ -4,7 +4,8 @@
 SUBSYSTEM=="cpu", ACTION=="add", TEST=="online", ATTR{online}=="0", ATTR{online}="1"
 
 # Memory hotadd request
-SUBSYSTEM!="memory", ACTION!="add", GOTO="memory_hotplug_end"
+SUBSYSTEM!="memory", GOTO="memory_hotplug_end"
+ACTION!="add", GOTO="memory_hotplug_end"
 PROGRAM="/bin/uname -p", RESULT=="s390*", GOTO="memory_hotplug_end"
 
 ENV{.state}="online"


### PR DESCRIPTION
Fixes a bug introduced in commit c50b7bcbebcfebfce3a7e7fb77f88f4b590fb2b5.

Resolves: #1666612