### PR TITLE
(#1626382) core: disable the effect of Restart= if there's a stop job pending fo…

### DIFF
--- a/src/core/service.c
+++ b/src/core/service.c
@@ -1271,7 +1271,13 @@ static int cgroup_good(Service *s) {
 
 static void service_enter_dead(Service *s, ServiceResult f, bool allow_restart) {
         int r;
+
         assert(s);
+
+        /* If there's a stop job queued before we enter the DEAD state, we shouldn't act on Restart=, in order to not
+         * undo what has already been enqueued. */
+        if (unit_stop_pending(UNIT(s)))
+                allow_restart = false;
 
         if (f != SERVICE_SUCCESS)
                 s->result = f;


### PR DESCRIPTION
…r a service (#6581)

We shouldn't undo the job already enqueued, under any circumstances.

Fixes: #6504
(cherry picked from commit 0f52f8e552f869269f02f0359c2d1019cc39f15a)

Resolves: #1626382