### PR TITLE
(#1627750) local-addresses: handle gracefully if routes lack an RTA_OIF attribute

### DIFF
--- a/src/libsystemd/sd-rtnl/local-addresses.c
+++ b/src/libsystemd/sd-rtnl/local-addresses.c
@@ -225,6 +225,8 @@ int local_gateways(sd_rtnl *context, int ifindex, int af, struct local_address *
                         continue;
 
                 r = sd_rtnl_message_read_u32(m, RTA_OIF, &ifi);
+                if (r == -ENODATA) /* Not all routes have an RTA_OIF attribute (for example nexthop ones) */
+                        continue;
                 if (r < 0)
                         return r;
                 if (ifindex > 0 && (int) ifi != ifindex)


### PR DESCRIPTION
Some routes (such as those using "nexthop") don't have an RTA_OIF
attribute. We need to handle that gracefully, by simply ignoring the
route.

Fixes: #7854
(cherry picked from commit 568fc5c3f7223770b8f3471da314745742125bb9)

Resolves: #1627750