### PR TITLE
(#1653824) Revert "sysctl.d: switch net.ipv4.conf.all.rp_filter from 1 to 2"

### DIFF
--- a/sysctl.d/50-default.conf
+++ b/sysctl.d/50-default.conf
@@ -22,7 +22,7 @@ kernel.sysrq = 16
 kernel.core_uses_pid = 1
 
 # Source route verification
-net.ipv4.conf.all.rp_filter = 2
+net.ipv4.conf.all.rp_filter = 1
 
 # Do not accept source routing
 net.ipv4.conf.all.accept_source_route = 0


### PR DESCRIPTION
This reverts commit 75c9af80cf3529c76988451e63f98010c86f48f1.

Resolves: #1653824