### PR TITLE
test: replace echo with socat

### DIFF
--- a/test/TEST-10-ISSUE-2467/test.sh
+++ b/test/TEST-10-ISSUE-2467/test.sh
@@ -17,7 +17,7 @@ test_setup() {
         eval $(udevadm info --export --query=env --name=${LOOPDEV}p2)
 
         setup_basic_environment
-        dracut_install true rm
+        dracut_install true rm socat
 
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<'EOF'
@@ -29,13 +29,13 @@ After=multi-user.target
 Type=oneshot
 StandardOutput=tty
 StandardError=tty
-ExecStart=/bin/sh -e -x -c 'rm -f /tmp/nonexistent; systemctl start test.socket; echo > /run/test.ctl; >/testok'
+ExecStart=/bin/sh -e -x -c 'rm -f /tmp/nonexistent; systemctl start test.socket; printf x > test.file; socat -t20 OPEN:test.file UNIX-CONNECT:/run/test.ctl; >/testok'
 TimeoutStartSec=10s
 EOF
 
 	cat  >$initdir/etc/systemd/system/test.socket <<'EOF'
 [Socket]
-ListenFIFO=/run/test.ctl
+ListenStream=/run/test.ctl
 EOF
 
 	cat > $initdir/etc/systemd/system/test.service <<'EOF'


### PR DESCRIPTION
The original version of the test used netcat along with a standard
AF_UNIX socket, which caused issues across different netcat
implementations. The AF_UNIX socket was then replaced by a FIFO with a
simple echo, which, however, suffers from the same issue (some echo
implementations don't check if the write() was successful).

Let's revert back to the AF_UNIX socket, but replace netcat with socat,
which, hopefully, resolves the main issue.

Relevant commit: 9b45c2bf02a43e3e1b42de1ab0c3fe29c64dc5f5

(cherry picked from commit b35d6d828b3216d022e565820d9971cb0f7746c1)

---

After merging I'll re-enable this test in the CentOS CI (https://github.com/systemd/systemd-centos-ci/pull/67).