### PR TITLE
Fix & enable LGTM on RHEL7

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,9 @@
+extraction:
+  cpp:
+    configure:
+      command:
+        - ./autogen.sh
+        - ./configure --disable-timesyncd --disable-kdbus --disable-terminal
+                      --disable-gtk-doc --disable-manpages --disable-gtk-doc-html
+                      --enable-compat-libs --disable-sysusers --disable-ldconfig
+                      --enable-lz4 --disable-microhttpd

--- a/configure.ac
+++ b/configure.ac
@@ -237,6 +237,28 @@ AC_CHECK_SIZEOF(rlim_t,,[
        #include <sys/resource.h>
 ])
 
+GPERF_TEST="$(echo foo,bar | ${GPERF} -L ANSI-C)"
+
+AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([
+                #include <string.h>
+                const char * in_word_set(const char *, size_t);
+                $GPERF_TEST]
+        )],
+        [GPERF_LEN_TYPE=size_t],
+        [AC_COMPILE_IFELSE(
+                [AC_LANG_PROGRAM([
+                        #include <string.h>
+                        const char * in_word_set(const char *, unsigned);
+                        $GPERF_TEST]
+                )],
+                [GPERF_LEN_TYPE=unsigned],
+                [AC_MSG_ERROR([** unable to determine gperf len type])]
+        )]
+)
+
+AC_DEFINE_UNQUOTED([GPERF_LEN_TYPE], [$GPERF_LEN_TYPE], [gperf len type])
+
 # ------------------------------------------------------------------------------
 # we use python to build the man page index, and for systemd-python
 have_python=no

--- a/src/core/load-fragment.h
+++ b/src/core/load-fragment.h
@@ -112,7 +112,7 @@ int config_parse_protect_system(const char* unit, const char *filename, unsigned
 int config_parse_bus_name(const char* unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 
 /* gperf prototypes */
-const struct ConfigPerfItem* load_fragment_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* load_fragment_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 extern const char load_fragment_gperf_nulstr[];
 
 typedef enum Disabled {

--- a/src/journal/journald-server.h
+++ b/src/journal/journald-server.h
@@ -164,7 +164,7 @@ void server_dispatch_message(Server *s, struct iovec *iovec, unsigned n, unsigne
 void server_driver_message(Server *s, sd_id128_t message_id, const char *format, ...) _printf_(3,4);
 
 /* gperf lookup function */
-const struct ConfigPerfItem* journald_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* journald_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int config_parse_storage(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 int config_parse_line_max(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);

--- a/src/login/logind.h
+++ b/src/login/logind.h
@@ -187,7 +187,7 @@ int manager_unit_is_active(Manager *manager, const char *unit);
 int manager_job_is_active(Manager *manager, const char *path);
 
 /* gperf lookup function */
-const struct ConfigPerfItem* logind_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* logind_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int manager_watch_busname(Manager *manager, const char *name);
 void manager_drop_busname(Manager *manager, const char *name);

--- a/src/network/networkd-netdev.h
+++ b/src/network/networkd-netdev.h
@@ -199,7 +199,7 @@ NetDevKind netdev_kind_from_string(const char *d) _pure_;
 int config_parse_netdev_kind(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 
 /* gperf */
-const struct ConfigPerfItem* network_netdev_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* network_netdev_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 /* Macros which append INTERFACE= to the message */
 

--- a/src/network/networkd.h
+++ b/src/network/networkd.h
@@ -328,7 +328,7 @@ int network_node_enumerator(sd_bus *bus, const char *path, void *userdata, char 
 int network_object_find(sd_bus *bus, const char *path, const char *interface, void *userdata, void **found, sd_bus_error *error);
 
 /* gperf */
-const struct ConfigPerfItem* network_network_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* network_network_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 /* Route */
 int route_new_static(Network *network, unsigned section, Route **ret);

--- a/src/resolve/dns-type.c
+++ b/src/resolve/dns-type.c
@@ -27,7 +27,7 @@ typedef const struct {
 } dns_type;
 
 static const struct dns_type_name *
-lookup_dns_type (register const char *str, register unsigned int len);
+lookup_dns_type (register const char *str, register GPERF_LEN_TYPE len);
 
 #include "dns_type-from-name.h"
 #include "dns_type-to-name.h"

--- a/src/resolve/resolved-conf.h
+++ b/src/resolve/resolved-conf.h
@@ -26,7 +26,7 @@
 int manager_parse_dns_server(Manager *m, DnsServerType type, const char *string);
 int manager_parse_config_file(Manager *m);
 
-const struct ConfigPerfItem* resolved_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* resolved_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int config_parse_dnsv(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 int config_parse_support(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);

--- a/src/shared/af-list.c
+++ b/src/shared/af-list.c
@@ -25,7 +25,7 @@
 #include "util.h"
 #include "af-list.h"
 
-static const struct af_name* lookup_af(register const char *str, register unsigned int len);
+static const struct af_name* lookup_af(register const char *str, register GPERF_LEN_TYPE len);
 
 #include "af-to-name.h"
 #include "af-from-name.h"

--- a/src/shared/arphrd-list.c
+++ b/src/shared/arphrd-list.c
@@ -26,7 +26,7 @@
 #include "util.h"
 #include "arphrd-list.h"
 
-static const struct arphrd_name* lookup_arphrd(register const char *str, register unsigned int len);
+static const struct arphrd_name* lookup_arphrd(register const char *str, register GPERF_LEN_TYPE len);
 
 #include "arphrd-to-name.h"
 #include "arphrd-from-name.h"

--- a/src/shared/cap-list.c
+++ b/src/shared/cap-list.c
@@ -26,7 +26,7 @@
 #include "cap-list.h"
 #include "missing.h"
 
-static const struct capability_name* lookup_capability(register const char *str, register unsigned int len);
+static const struct capability_name* lookup_capability(register const char *str, register GPERF_LEN_TYPE len);
 
 #include "cap-to-name.h"
 #include "cap-from-name.h"

--- a/src/shared/conf-parser.h
+++ b/src/shared/conf-parser.h
@@ -61,7 +61,7 @@ typedef struct ConfigPerfItem {
 } ConfigPerfItem;
 
 /* Prototype for a low-level gperf lookup function */
-typedef const ConfigPerfItem* (*ConfigPerfItemLookup)(const char *section_and_lvalue, unsigned length);
+typedef const ConfigPerfItem* (*ConfigPerfItemLookup)(const char *section_and_lvalue, GPERF_LEN_TYPE length);
 
 /* Prototype for a generic high-level lookup function */
 typedef int (*ConfigItemLookup)(

--- a/src/shared/errno-list.c
+++ b/src/shared/errno-list.c
@@ -26,7 +26,7 @@
 #include "errno-list.h"
 
 static const struct errno_name* lookup_errno(register const char *str,
-                                                 register unsigned int len);
+                                             register GPERF_LEN_TYPE len);
 
 #include "errno-to-name.h"
 #include "errno-from-name.h"

--- a/src/timesync/timesyncd-conf.h
+++ b/src/timesync/timesyncd-conf.h
@@ -25,7 +25,7 @@
 
 #include "timesyncd-manager.h"
 
-const struct ConfigPerfItem* timesyncd_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* timesyncd_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int manager_parse_server_string(Manager *m, ServerType type, const char *string);
 

--- a/src/udev/net/link-config.h
+++ b/src/udev/net/link-config.h
@@ -93,7 +93,7 @@ const char *mac_policy_to_string(MACPolicy p) _const_;
 MACPolicy mac_policy_from_string(const char *p) _pure_;
 
 /* gperf lookup function */
-const struct ConfigPerfItem* link_config_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* link_config_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int config_parse_mac_policy(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 int config_parse_name_policy(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);

--- a/src/udev/udev-builtin-keyboard.c
+++ b/src/udev/udev-builtin-keyboard.c
@@ -28,7 +28,7 @@
 
 #include "udev.h"
 
-static const struct key *keyboard_lookup_key(const char *str, unsigned len);
+static const struct key *keyboard_lookup_key(const char *str, GPERF_LEN_TYPE len);
 #include "keyboard-keys-from-name.h"
 #include "keyboard-keys-to-name.h"
 


### PR DESCRIPTION
Let's attempt to fix outstanding issues which prevent the LGTM C analysis to be enabled for RHEL 7 (and then for RHEL 8 as well) branch.

Related LGTM issue: https://discuss.lgtm.com/t/missing-c-analysis-in-downstream-systemd-project/1769

The first one is following compilation error in LGTM infra:

```
[2019-01-18 21:46:47] [build]   CC       src/shared/libsystemd_shared_la-errno-list.lo
[2019-01-18 21:46:49] [build] In file included from src/shared/errno-list.c:32:0:
[2019-01-18 21:46:49] [build] src/shared/errno-from-name.h:143:1: error: conflicting types for ‘lookup_errno’
[2019-01-18 21:46:49] [build]  lookup_errno (register const char *str, register size_t len)
[2019-01-18 21:46:49] [build]  ^~~~~~~~~~~~
[2019-01-18 21:46:49] [build] src/shared/errno-list.c:28:33: note: previous declaration of ‘lookup_errno’ was here
[2019-01-18 21:46:49] [build]  static const struct errno_name* lookup_errno(register const char *str,
[2019-01-18 21:46:49] [build]                                  ^~~~~~~~~~~~
[2019-01-18 21:46:49] [build] Makefile:16172: recipe for target 'src/shared/libsystemd_shared_la-errno-list.lo' failed
[2019-01-18 21:46:49] [build] make[2]: *** [src/shared/libsystemd_shared_la-errno-list.lo] Error 1
[2019-01-18 21:46:49] [build] make[1]: *** [all-recursive] Error 1
[2019-01-18 21:46:49] [build] Makefile:19109: recipe for target 'all-recursive' failed
```

This should be fixed by https://github.com/systemd/systemd/pull/5055.