### PR TITLE
(#1683319) travis: enable ASan and UBSan on RHEL8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: xenial
 services:
     - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ env:
 
 jobs:
     include:
-        - stage: Build & test
-          name: CentOS 7
+        - name: CentOS 7
           language: bash
           env:
               - CENTOS_RELEASE="centos7"
@@ -25,6 +24,26 @@ jobs:
               - set -e
               # Build systemd
               - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh RUN
+              - set +e
+          after_script:
+              - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh CLEANUP
+
+        - name: CentOS 7 (ASan+UBSan)
+          language: bash
+          env:
+              - CENTOS_RELEASE="centos7"
+              - CONT_NAME="systemd-centos-$CENTOS_RELEASE"
+              - DOCKER_EXEC="docker exec -ti $CONT_NAME"
+          before_install:
+              - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+              - docker --version
+          install:
+              - if [ -f meson.build ]; then RHEL_VERSION=rhel8; else RHEL_VERSION=rhel7; fi
+              - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh SETUP
+          script:
+              - set -e
+              # Build systemd
+              - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh RUN_ASAN
               - set +e
           after_script:
               - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh CLEANUP

--- a/ci/travis-centos-rhel8.sh
+++ b/ci/travis-centos-rhel8.sh
@@ -19,6 +19,60 @@ ADDITIONAL_DEPS=(systemd-ci-environment libidn2-devel python-lxml python36 ninja
 # Repo with additional depencencies to compile newer systemd on CentOS 7
 COPR_REPO="https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci/repo/epel-7/mrc0mmand-systemd-centos-ci-epel-7.repo"
 COPR_REPO_PATH="/etc/yum.repos.d/${COPR_REPO##*/}"
+# RHEL8 options
+CONFIGURE_OPTS=(
+    -Dsysvinit-path=/etc/rc.d/init.d
+    -Drc-local=/etc/rc.d/rc.local
+    -Ddns-servers=''
+    -Ddev-kvm-mode=0666
+    -Dkmod=true
+    -Dxkbcommon=true
+    -Dblkid=true
+    -Dseccomp=true
+    -Dima=true
+    -Dselinux=true
+    -Dapparmor=false
+    -Dpolkit=true
+    -Dxz=true
+    -Dzlib=true
+    -Dbzip2=true
+    -Dlz4=true
+    -Dpam=true
+    -Dacl=true
+    -Dsmack=true
+    -Dgcrypt=true
+    -Daudit=true
+    -Delfutils=true
+    -Dlibcryptsetup=true
+    -Delfutils=true
+    -Dqrencode=false
+    -Dgnutls=true
+    -Dmicrohttpd=true
+    -Dlibidn2=true
+    -Dlibiptc=true
+    -Dlibcurl=true
+    -Defi=true
+    -Dtpm=true
+    -Dhwdb=true
+    -Dsysusers=true
+    -Ddefault-kill-user-processes=false
+    -Dtests=unsafe
+    -Dinstall-tests=true
+    -Dtty-gid=5
+    -Dusers-gid=100
+    -Dnobody-user=nobody
+    -Dnobody-group=nobody
+    -Dsplit-usr=false
+    -Dsplit-bin=true
+    -Db_lto=false
+    -Dnetworkd=false
+    -Dtimesyncd=false
+    -Ddefault-hierarchy=legacy
+    # Custom options
+    -Dslow-tests=true
+    -Dtests=unsafe
+    -Dinstall-tests=true
+)
 
 function info() {
     echo -e "\033[33;1m$1\033[0m"
@@ -57,60 +111,6 @@ for phase in "${PHASES[@]}"; do
         RUN)
             info "Run phase"
             # Build systemd
-            CONFIGURE_OPTS=(
-                # RHEL8 options
-                -Dsysvinit-path=/etc/rc.d/init.d
-                -Drc-local=/etc/rc.d/rc.local
-                -Ddns-servers=''
-                -Ddev-kvm-mode=0666
-                -Dkmod=true
-                -Dxkbcommon=true
-                -Dblkid=true
-                -Dseccomp=true
-                -Dima=true
-                -Dselinux=true
-                -Dapparmor=false
-                -Dpolkit=true
-                -Dxz=true
-                -Dzlib=true
-                -Dbzip2=true
-                -Dlz4=true
-                -Dpam=true
-                -Dacl=true
-                -Dsmack=true
-                -Dgcrypt=true
-                -Daudit=true
-                -Delfutils=true
-                -Dlibcryptsetup=true
-                -Delfutils=true
-                -Dqrencode=false
-                -Dgnutls=true
-                -Dmicrohttpd=true
-                -Dlibidn2=true
-                -Dlibiptc=true
-                -Dlibcurl=true
-                -Defi=true
-                -Dtpm=true
-                -Dhwdb=true
-                -Dsysusers=true
-                -Ddefault-kill-user-processes=false
-                -Dtests=unsafe
-                -Dinstall-tests=true
-                -Dtty-gid=5
-                -Dusers-gid=100
-                -Dnobody-user=nobody
-                -Dnobody-group=nobody
-                -Dsplit-usr=false
-                -Dsplit-bin=true
-                -Db_lto=false
-                -Dnetworkd=false
-                -Dtimesyncd=false
-                -Ddefault-hierarchy=legacy
-                # Custom options
-                -Dslow-tests=true
-                -Dtests=unsafe
-                -Dinstall-tests=true
-            )
             docker exec -it -e CFLAGS='-g -O0 -ftrapv' $CONT_NAME meson build "${CONFIGURE_OPTS[@]}"
             $DOCKER_EXEC ninja -v -C build
             # Let's install the new systemd and "reboot" the container to avoid
@@ -121,6 +121,36 @@ for phase in "${PHASES[@]}"; do
             # and it's pointless to run it on a VM in a Docker container...
             echo -ne "#!/usr/bin/perl\nexit(0);\n" > "test/udev-test.pl"
             $DOCKER_EXEC ninja -C build test
+            ;;
+        RUN_ASAN|RUN_CLANG_ASAN)
+            # Let's install newer gcc for proper ASan/UBSan support
+            $DOCKER_EXEC yum -y install centos-release-scl
+            $DOCKER_EXEC yum -y install devtoolset-8 devtoolset-8-libasan-devel libasan5 devtoolset-8-libubsan-devel libubsan1
+            $DOCKER_EXEC bash -c "echo 'source scl_source enable devtoolset-8' >> /root/.bashrc"
+            # Note to my future frustrated self: docker exec runs the given command
+            # as sh -c 'command' - which means both .bash_profile and .bashrc will
+            # be ignored. That's because .bash_profile is sourced for LOGIN shells (i.e.
+            # sh -l), whereas .bashrc is sourced for NON-LOGIN INTERACTIVE shells
+            # (i.e. sh -i).
+            # As the default docker exec command lacks either of those options,
+            # we need to use a wrapper command which runs the wanted command
+            # under an explicit bash -i, so the SCL source above works properly.
+            docker exec -it $CONT_NAME bash -ic 'gcc --version'
+
+            if [[ "$phase" = "RUN_CLANG_ASAN" ]]; then
+                ENV_VARS="-e CC=clang -e CXX=clang++"
+                MESON_ARGS="-Db_lundef=false" # See https://github.com/mesonbuild/meson/issues/764
+            fi
+            docker exec $ENV_VARS -it $CONT_NAME bash -ic "meson build --werror -Dtests=unsafe -Db_sanitize=address,undefined $MESON_ARGS ${CONFIGURE_OPTS[@]}"
+            docker exec -it $CONT_NAME bash -ic 'ninja -v -C build'
+
+            # Never remove halt_on_error from UBSAN_OPTIONS. See https://github.com/systemd/systemd/commit/2614d83aa06592aedb.
+            travis_wait docker exec --interactive=false \
+                -e UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1 \
+                -e ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1 \
+                -e "TRAVIS=$TRAVIS" \
+                -t $CONT_NAME \
+                bash -ic 'meson test --timeout-multiplier=3 -C ./build/ --print-errorlogs'
             ;;
         CLEANUP)
             info "Cleanup phase"

--- a/src/basic/bitmap.c
+++ b/src/basic/bitmap.c
@@ -206,7 +206,7 @@ bool bitmap_equal(Bitmap *a, Bitmap *b) {
                 return true;
 
         common_n_bitmaps = MIN(a->n_bitmaps, b->n_bitmaps);
-        if (memcmp(a->bitmaps, b->bitmaps, sizeof(uint64_t) * common_n_bitmaps) != 0)
+        if (memcmp_safe(a->bitmaps, b->bitmaps, sizeof(uint64_t) * common_n_bitmaps) != 0)
                 return false;
 
         c = a->n_bitmaps > b->n_bitmaps ? a : b;

--- a/src/basic/capability-util.h
+++ b/src/basic/capability-util.h
@@ -39,3 +39,7 @@ static inline bool cap_test_all(uint64_t caps) {
 }
 
 bool ambient_capabilities_supported(void);
+
+/* Identical to linux/capability.h's CAP_TO_MASK(), but uses an unsigned 1U instead of a signed 1 for shifting left, in
+ * order to avoid complaints about shifting a signed int left by 31 bits, which would make it negative. */
+#define CAP_TO_MASK_CORRECTED(x) (1U << ((x) & 31U))

--- a/src/basic/mount-util.c
+++ b/src/basic/mount-util.c
@@ -109,7 +109,7 @@ static int fd_fdinfo_mnt_id(int fd, const char *filename, int flags, int *mnt_id
         if ((flags & AT_EMPTY_PATH) && isempty(filename))
                 xsprintf(path, "/proc/self/fdinfo/%i", fd);
         else {
-                subfd = openat(fd, filename, O_CLOEXEC|O_PATH);
+                subfd = openat(fd, filename, O_CLOEXEC|O_PATH|(flags & AT_SYMLINK_FOLLOW ? 0 : O_NOFOLLOW));
                 if (subfd < 0)
                         return -errno;
 

--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -1003,9 +1003,10 @@ int getpeergroups(int fd, gid_t **ret) {
         return (int) n;
 }
 
-int send_one_fd_sa(
+ssize_t send_one_fd_iov_sa(
                 int transport_fd,
                 int fd,
+                struct iovec *iov, size_t iovlen,
                 const struct sockaddr *sa, socklen_t len,
                 int flags) {
 
@@ -1016,28 +1017,58 @@ int send_one_fd_sa(
         struct msghdr mh = {
                 .msg_name = (struct sockaddr*) sa,
                 .msg_namelen = len,
-                .msg_control = &control,
-                .msg_controllen = sizeof(control),
+                .msg_iov = iov,
+                .msg_iovlen = iovlen,
         };
-        struct cmsghdr *cmsg;
+        ssize_t k;
 
         assert(transport_fd >= 0);
-        assert(fd >= 0);
 
-        cmsg = CMSG_FIRSTHDR(&mh);
-        cmsg->cmsg_level = SOL_SOCKET;
-        cmsg->cmsg_type = SCM_RIGHTS;
-        cmsg->cmsg_len = CMSG_LEN(sizeof(int));
-        memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
+        /*
+         * We need either an FD or data to send.
+         * If there's nothing, return an error.
+         */
+        if (fd < 0 && !iov)
+                return -EINVAL;
 
-        mh.msg_controllen = CMSG_SPACE(sizeof(int));
-        if (sendmsg(transport_fd, &mh, MSG_NOSIGNAL | flags) < 0)
-                return -errno;
+        if (fd >= 0) {
+                struct cmsghdr *cmsg;
 
-        return 0;
+                mh.msg_control = &control;
+                mh.msg_controllen = sizeof(control);
+
+                cmsg = CMSG_FIRSTHDR(&mh);
+                cmsg->cmsg_level = SOL_SOCKET;
+                cmsg->cmsg_type = SCM_RIGHTS;
+                cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+                memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
+
+                mh.msg_controllen = CMSG_SPACE(sizeof(int));
+        }
+        k = sendmsg(transport_fd, &mh, MSG_NOSIGNAL | flags);
+        if (k < 0)
+                return (ssize_t) -errno;
+
+        return k;
 }
 
-int receive_one_fd(int transport_fd, int flags) {
+int send_one_fd_sa(
+                int transport_fd,
+                int fd,
+                const struct sockaddr *sa, socklen_t len,
+                int flags) {
+
+        assert(fd >= 0);
+
+        return (int) send_one_fd_iov_sa(transport_fd, fd, NULL, 0, sa, len, flags);
+}
+
+ssize_t receive_one_fd_iov(
+                int transport_fd,
+                struct iovec *iov, size_t iovlen,
+                int flags,
+                int *ret_fd) {
+
         union {
                 struct cmsghdr cmsghdr;
                 uint8_t buf[CMSG_SPACE(sizeof(int))];
@@ -1045,10 +1076,14 @@ int receive_one_fd(int transport_fd, int flags) {
         struct msghdr mh = {
                 .msg_control = &control,
                 .msg_controllen = sizeof(control),
+                .msg_iov = iov,
+                .msg_iovlen = iovlen,
         };
         struct cmsghdr *cmsg, *found = NULL;
+        ssize_t k;
 
         assert(transport_fd >= 0);
+        assert(ret_fd);
 
         /*
          * Receive a single FD via @transport_fd. We don't care for
@@ -1058,8 +1093,9 @@ int receive_one_fd(int transport_fd, int flags) {
          * combination with send_one_fd().
          */
 
-        if (recvmsg(transport_fd, &mh, MSG_CMSG_CLOEXEC | flags) < 0)
-                return -errno;
+        k = recvmsg(transport_fd, &mh, MSG_CMSG_CLOEXEC | flags);
+        if (k < 0)
+                return (ssize_t) -errno;
 
         CMSG_FOREACH(cmsg, &mh) {
                 if (cmsg->cmsg_level == SOL_SOCKET &&
@@ -1071,12 +1107,33 @@ int receive_one_fd(int transport_fd, int flags) {
                 }
         }
 
-        if (!found) {
+        if (!found)
                 cmsg_close_all(&mh);
-                return -EIO;
-        }
 
-        return *(int*) CMSG_DATA(found);
+        /* If didn't receive an FD or any data, return an error. */
+        if (k == 0 && !found)
+                return -EIO;
+
+        if (found)
+                *ret_fd = *(int*) CMSG_DATA(found);
+        else
+                *ret_fd = -1;
+
+        return k;
+}
+
+int receive_one_fd(int transport_fd, int flags) {
+        int fd;
+        ssize_t k;
+
+        k = receive_one_fd_iov(transport_fd, NULL, 0, flags, &fd);
+        if (k == 0)
+                return fd;
+
+        /* k must be negative, since receive_one_fd_iov() only returns
+         * a positive value if data was received through the iov. */
+        assert(k < 0);
+        return (int) k;
 }
 
 ssize_t next_datagram_size_fd(int fd) {

--- a/src/basic/socket-util.h
+++ b/src/basic/socket-util.h
@@ -130,11 +130,19 @@ int getpeercred(int fd, struct ucred *ucred);
 int getpeersec(int fd, char **ret);
 int getpeergroups(int fd, gid_t **ret);
 
+ssize_t send_one_fd_iov_sa(
+                int transport_fd,
+                int fd,
+                struct iovec *iov, size_t iovlen,
+                const struct sockaddr *sa, socklen_t len,
+                int flags);
 int send_one_fd_sa(int transport_fd,
                    int fd,
                    const struct sockaddr *sa, socklen_t len,
                    int flags);
-#define send_one_fd(transport_fd, fd, flags) send_one_fd_sa(transport_fd, fd, NULL, 0, flags)
+#define send_one_fd_iov(transport_fd, fd, iov, iovlen, flags) send_one_fd_iov_sa(transport_fd, fd, iov, iovlen, NULL, 0, flags)
+#define send_one_fd(transport_fd, fd, flags) send_one_fd_iov_sa(transport_fd, fd, NULL, 0, NULL, 0, flags)
+ssize_t receive_one_fd_iov(int transport_fd, struct iovec *iov, size_t iovlen, int flags, int *ret_fd);
 int receive_one_fd(int transport_fd, int flags);
 
 ssize_t next_datagram_size_fd(int fd);

--- a/src/basic/util.h
+++ b/src/basic/util.h
@@ -113,14 +113,21 @@ static inline void qsort_r_safe(void *base, size_t nmemb, size_t size, int (*com
         qsort_r(base, nmemb, size, compar, userdata);
 }
 
-/**
- * Normal memcpy requires src to be nonnull. We do nothing if n is 0.
- */
+/* Normal memcpy requires src to be nonnull. We do nothing if n is 0. */
 static inline void memcpy_safe(void *dst, const void *src, size_t n) {
         if (n == 0)
                 return;
         assert(src);
         memcpy(dst, src, n);
+}
+
+/* Normal memcmp requires s1 and s2 to be nonnull. We do nothing if n is 0. */
+static inline int memcmp_safe(const void *s1, const void *s2, size_t n) {
+        if (n == 0)
+                return 0;
+        assert(s1);
+        assert(s2);
+        return memcmp(s1, s2, n);
 }
 
 int on_ac_power(void);

--- a/src/basic/util.h
+++ b/src/basic/util.h
@@ -125,7 +125,13 @@ static inline void memcpy_safe(void *dst, const void *src, size_t n) {
 
 int on_ac_power(void);
 
-#define memzero(x,l) (memset((x), 0, (l)))
+#define memzero(x,l)                                            \
+        ({                                                      \
+                size_t _l_ = (l);                               \
+                void *_x_ = (x);                                \
+                _l_ == 0 ? _x_ : memset(_x_, 0, _l_);           \
+        })
+
 #define zero(x) (memzero(&(x), sizeof(x)))
 
 static inline void *mempset(void *s, int c, size_t n) {

--- a/src/journal/sd-journal.c
+++ b/src/journal/sd-journal.c
@@ -16,6 +16,7 @@
 #include "catalog.h"
 #include "compress.h"
 #include "dirent-util.h"
+#include "escape.h"
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-util.h"
@@ -381,7 +382,7 @@ static char *match_make_string(Match *m) {
                 return strdup("none");
 
         if (m->type == MATCH_DISCRETE)
-                return strndup(m->data, m->size);
+                return cescape_length(m->data, m->size);
 
         LIST_FOREACH(matches, i, m->matches) {
                 char *t, *k;

--- a/src/journal/test-journal-match.c
+++ b/src/journal/test-journal-match.c
@@ -23,6 +23,8 @@ int main(int argc, char *argv[]) {
         assert_se(sd_journal_add_match(j, "", 0) < 0);
         assert_se(sd_journal_add_match(j, "=", 0) < 0);
         assert_se(sd_journal_add_match(j, "=xxxxx", 0) < 0);
+        assert_se(sd_journal_add_match(j, (uint8_t[4]){'A', '=', '\1', '\2'}, 4) >= 0);
+        assert_se(sd_journal_add_match(j, (uint8_t[5]){'B', '=', 'C', '\0', 'D'}, 5) >= 0);
         assert_se(sd_journal_add_match(j, "HALLO=WALDO", 0) >= 0);
         assert_se(sd_journal_add_match(j, "QUUX=mmmm", 0) >= 0);
         assert_se(sd_journal_add_match(j, "QUUX=xxxxx", 0) >= 0);
@@ -53,7 +55,7 @@ int main(int argc, char *argv[]) {
 
         printf("resulting match expression is: %s\n", t);
 
-        assert_se(streq(t, "(((L3=ok OR L3=yes) OR ((L4_2=ok OR L4_2=yes) AND (L4_1=ok OR L4_1=yes))) AND ((TWO=two AND (ONE=two OR ONE=one)) OR (PIFF=paff AND (QUUX=yyyyy OR QUUX=xxxxx OR QUUX=mmmm) AND (HALLO= OR HALLO=WALDO))))"));
+        assert_se(streq(t, "(((L3=ok OR L3=yes) OR ((L4_2=ok OR L4_2=yes) AND (L4_1=ok OR L4_1=yes))) AND ((TWO=two AND (ONE=two OR ONE=one)) OR (PIFF=paff AND (QUUX=yyyyy OR QUUX=xxxxx OR QUUX=mmmm) AND (HALLO= OR HALLO=WALDO) AND B=C\\000D AND A=\\001\\002)))"));
 
         return 0;
 }

--- a/src/libsystemd/sd-bus/bus-creds.c
+++ b/src/libsystemd/sd-bus/bus-creds.c
@@ -651,7 +651,7 @@ _public_ int sd_bus_creds_get_description(sd_bus_creds *c, const char **ret) {
         return 0;
 }
 
-static int has_cap(sd_bus_creds *c, unsigned offset, int capability) {
+static int has_cap(sd_bus_creds *c, size_t offset, int capability) {
         size_t sz;
 
         assert(c);

--- a/src/libsystemd/sd-bus/bus-creds.c
+++ b/src/libsystemd/sd-bus/bus-creds.c
@@ -663,7 +663,7 @@ static int has_cap(sd_bus_creds *c, unsigned offset, int capability) {
 
         sz = DIV_ROUND_UP(cap_last_cap(), 32U);
 
-        return !!(c->capability[offset * sz + CAP_TO_INDEX(capability)] & CAP_TO_MASK(capability));
+        return !!(c->capability[offset * sz + CAP_TO_INDEX((uint32_t) capability)] & CAP_TO_MASK_CORRECTED((uint32_t) capability));
 }
 
 _public_ int sd_bus_creds_has_effective_cap(sd_bus_creds *c, int capability) {

--- a/src/libsystemd/sd-bus/bus-creds.c
+++ b/src/libsystemd/sd-bus/bus-creds.c
@@ -652,16 +652,19 @@ _public_ int sd_bus_creds_get_description(sd_bus_creds *c, const char **ret) {
 }
 
 static int has_cap(sd_bus_creds *c, size_t offset, int capability) {
+        unsigned long lc;
         size_t sz;
 
         assert(c);
         assert(capability >= 0);
         assert(c->capability);
 
-        if ((unsigned) capability > cap_last_cap())
+        lc = cap_last_cap();
+
+        if ((unsigned long) capability > lc)
                 return 0;
 
-        sz = DIV_ROUND_UP(cap_last_cap(), 32U);
+        sz = DIV_ROUND_UP(lc, 32LU);
 
         return !!(c->capability[offset * sz + CAP_TO_INDEX((uint32_t) capability)] & CAP_TO_MASK_CORRECTED((uint32_t) capability));
 }

--- a/src/test/test-capability.c
+++ b/src/test/test-capability.c
@@ -19,8 +19,13 @@
 static uid_t test_uid = -1;
 static gid_t test_gid = -1;
 
+#ifdef __SANITIZE_ADDRESS__
+/* Keep CAP_SYS_PTRACE when running under Address Sanitizer */
+static const uint64_t test_flags = UINT64_C(1) << CAP_SYS_PTRACE;
+#else
 /* We keep CAP_DAC_OVERRIDE to avoid errors with gcov when doing test coverage */
-static uint64_t test_flags = 1ULL << CAP_DAC_OVERRIDE;
+static const uint64_t test_flags = UINT64_C(1) << CAP_DAC_OVERRIDE;
+#endif
 
 /* verify cap_last_cap() against /proc/sys/kernel/cap_last_cap */
 static void test_last_cap_file(void) {

--- a/src/test/test-hexdecoct.c
+++ b/src/test/test-hexdecoct.c
@@ -84,7 +84,7 @@ static void test_unhexmem_one(const char *s, size_t l, int retval) {
                         l = strlen(s);
 
                 assert_se(hex = hexmem(mem, len));
-                answer = strndupa(s, l);
+                answer = strndupa(s ?: "", l);
                 assert_se(streq(delete_chars(answer, WHITESPACE), hex));
         }
 }

--- a/src/test/test-socket-util.c
+++ b/src/test/test-socket-util.c
@@ -431,7 +431,6 @@ static void test_getpeercred_getpeergroups(void) {
         if (r == 0) {
                 static const gid_t gids[] = { 3, 4, 5, 6, 7 };
                 gid_t *test_gids;
-                _cleanup_free_ gid_t *peer_groups = NULL;
                 size_t n_test_gids;
                 uid_t test_uid;
                 gid_t test_gid;
@@ -472,12 +471,16 @@ static void test_getpeercred_getpeergroups(void) {
                 assert_se(ucred.gid == test_gid);
                 assert_se(ucred.pid == getpid_cached());
 
-                r = getpeergroups(pair[0], &peer_groups);
-                assert_se(r >= 0 || IN_SET(r, -EOPNOTSUPP, -ENOPROTOOPT));
+                {
+                        _cleanup_free_ gid_t *peer_groups = NULL;
 
-                if (r >= 0) {
-                        assert_se((size_t) r == n_test_gids);
-                        assert_se(memcmp(peer_groups, test_gids, sizeof(gid_t) * n_test_gids) == 0);
+                        r = getpeergroups(pair[0], &peer_groups);
+                        assert_se(r >= 0 || IN_SET(r, -EOPNOTSUPP, -ENOPROTOOPT));
+
+                        if (r >= 0) {
+                                assert_se((size_t) r == n_test_gids);
+                                assert_se(memcmp(peer_groups, test_gids, sizeof(gid_t) * n_test_gids) == 0);
+                        }
                 }
 
                 safe_close_pair(pair);

--- a/src/test/test-socket-util.c
+++ b/src/test/test-socket-util.c
@@ -6,8 +6,11 @@
 
 #include "alloc-util.h"
 #include "async.h"
+#include "exit-status.h"
 #include "fd-util.h"
+#include "fileio.h"
 #include "in-addr-util.h"
+#include "io-util.h"
 #include "log.h"
 #include "macro.h"
 #include "process-util.h"
@@ -484,7 +487,213 @@ static void test_getpeercred_getpeergroups(void) {
                 }
 
                 safe_close_pair(pair);
+                _exit(EXIT_SUCCESS);
         }
+}
+
+static void test_passfd_read(void) {
+        static const char file_contents[] = "test contents for passfd";
+        _cleanup_close_pair_ int pair[2] = { -1, -1 };
+        int r;
+
+        assert_se(socketpair(AF_UNIX, SOCK_DGRAM, 0, pair) >= 0);
+
+        r = safe_fork("(passfd_read)", FORK_DEATHSIG|FORK_LOG|FORK_WAIT, NULL);
+        assert_se(r >= 0);
+
+        if (r == 0) {
+                /* Child */
+                char tmpfile[] = "/tmp/test-socket-util-passfd-read-XXXXXX";
+                _cleanup_close_ int tmpfd = -1;
+
+                pair[0] = safe_close(pair[0]);
+
+                tmpfd = mkostemp_safe(tmpfile);
+                assert_se(tmpfd >= 0);
+                assert_se(write(tmpfd, file_contents, strlen(file_contents)) == (ssize_t) strlen(file_contents));
+                tmpfd = safe_close(tmpfd);
+
+                tmpfd = open(tmpfile, O_RDONLY);
+                assert_se(tmpfd >= 0);
+                assert_se(unlink(tmpfile) == 0);
+
+                assert_se(send_one_fd(pair[1], tmpfd, MSG_DONTWAIT) == 0);
+                _exit(EXIT_SUCCESS);
+        }
+
+        /* Parent */
+        char buf[64];
+        struct iovec iov = IOVEC_INIT(buf, sizeof(buf)-1);
+        _cleanup_close_ int fd = -1;
+
+        pair[1] = safe_close(pair[1]);
+
+        assert_se(receive_one_fd_iov(pair[0], &iov, 1, MSG_DONTWAIT, &fd) == 0);
+
+        assert_se(fd >= 0);
+        r = read(fd, buf, sizeof(buf)-1);
+        assert_se(r >= 0);
+        buf[r] = 0;
+        assert_se(streq(buf, file_contents));
+}
+
+static void test_passfd_contents_read(void) {
+        _cleanup_close_pair_ int pair[2] = { -1, -1 };
+        static const char file_contents[] = "test contents in the file";
+        static const char wire_contents[] = "test contents on the wire";
+        int r;
+
+        assert_se(socketpair(AF_UNIX, SOCK_DGRAM, 0, pair) >= 0);
+
+        r = safe_fork("(passfd_contents_read)", FORK_DEATHSIG|FORK_LOG|FORK_WAIT, NULL);
+        assert_se(r >= 0);
+
+        if (r == 0) {
+                /* Child */
+                struct iovec iov = IOVEC_INIT_STRING(wire_contents);
+                char tmpfile[] = "/tmp/test-socket-util-passfd-contents-read-XXXXXX";
+                _cleanup_close_ int tmpfd = -1;
+
+                pair[0] = safe_close(pair[0]);
+
+                tmpfd = mkostemp_safe(tmpfile);
+                assert_se(tmpfd >= 0);
+                assert_se(write(tmpfd, file_contents, strlen(file_contents)) == (ssize_t) strlen(file_contents));
+                tmpfd = safe_close(tmpfd);
+
+                tmpfd = open(tmpfile, O_RDONLY);
+                assert_se(tmpfd >= 0);
+                assert_se(unlink(tmpfile) == 0);
+
+                assert_se(send_one_fd_iov(pair[1], tmpfd, &iov, 1, MSG_DONTWAIT) > 0);
+                _exit(EXIT_SUCCESS);
+        }
+
+        /* Parent */
+        char buf[64];
+        struct iovec iov = IOVEC_INIT(buf, sizeof(buf)-1);
+        _cleanup_close_ int fd = -1;
+        ssize_t k;
+
+        pair[1] = safe_close(pair[1]);
+
+        k = receive_one_fd_iov(pair[0], &iov, 1, MSG_DONTWAIT, &fd);
+        assert_se(k > 0);
+        buf[k] = 0;
+        assert_se(streq(buf, wire_contents));
+
+        assert_se(fd >= 0);
+        r = read(fd, buf, sizeof(buf)-1);
+        assert_se(r >= 0);
+        buf[r] = 0;
+        assert_se(streq(buf, file_contents));
+}
+
+static void test_receive_nopassfd(void) {
+        _cleanup_close_pair_ int pair[2] = { -1, -1 };
+        static const char wire_contents[] = "no fd passed here";
+        int r;
+
+        assert_se(socketpair(AF_UNIX, SOCK_DGRAM, 0, pair) >= 0);
+
+        r = safe_fork("(receive_nopassfd)", FORK_DEATHSIG|FORK_LOG|FORK_WAIT, NULL);
+        assert_se(r >= 0);
+
+        if (r == 0) {
+                /* Child */
+                struct iovec iov = IOVEC_INIT_STRING(wire_contents);
+
+                pair[0] = safe_close(pair[0]);
+
+                assert_se(send_one_fd_iov(pair[1], -1, &iov, 1, MSG_DONTWAIT) > 0);
+                _exit(EXIT_SUCCESS);
+        }
+
+        /* Parent */
+        char buf[64];
+        struct iovec iov = IOVEC_INIT(buf, sizeof(buf)-1);
+        int fd = -999;
+        ssize_t k;
+
+        pair[1] = safe_close(pair[1]);
+
+        k = receive_one_fd_iov(pair[0], &iov, 1, MSG_DONTWAIT, &fd);
+        assert_se(k > 0);
+        buf[k] = 0;
+        assert_se(streq(buf, wire_contents));
+
+        /* no fd passed here, confirm it was reset */
+        assert_se(fd == -1);
+}
+
+static void test_send_nodata_nofd(void) {
+        _cleanup_close_pair_ int pair[2] = { -1, -1 };
+        int r;
+
+        assert_se(socketpair(AF_UNIX, SOCK_DGRAM, 0, pair) >= 0);
+
+        r = safe_fork("(send_nodata_nofd)", FORK_DEATHSIG|FORK_LOG|FORK_WAIT, NULL);
+        assert_se(r >= 0);
+
+        if (r == 0) {
+                /* Child */
+                pair[0] = safe_close(pair[0]);
+
+                assert_se(send_one_fd_iov(pair[1], -1, NULL, 0, MSG_DONTWAIT) == -EINVAL);
+                _exit(EXIT_SUCCESS);
+        }
+
+        /* Parent */
+        char buf[64];
+        struct iovec iov = IOVEC_INIT(buf, sizeof(buf)-1);
+        int fd = -999;
+        ssize_t k;
+
+        pair[1] = safe_close(pair[1]);
+
+        k = receive_one_fd_iov(pair[0], &iov, 1, MSG_DONTWAIT, &fd);
+        /* recvmsg() will return errno EAGAIN if nothing was sent */
+        assert_se(k == -EAGAIN);
+
+        /* receive_one_fd_iov returned error, so confirm &fd wasn't touched */
+        assert_se(fd == -999);
+}
+
+static void test_send_emptydata(void) {
+        _cleanup_close_pair_ int pair[2] = { -1, -1 };
+        int r;
+
+        assert_se(socketpair(AF_UNIX, SOCK_DGRAM, 0, pair) >= 0);
+
+        r = safe_fork("(send_emptydata)", FORK_DEATHSIG|FORK_LOG|FORK_WAIT, NULL);
+        assert_se(r >= 0);
+
+        if (r == 0) {
+                /* Child */
+                struct iovec iov = IOVEC_INIT_STRING("");  /* zero-length iov */
+                assert_se(iov.iov_len == 0);
+
+                pair[0] = safe_close(pair[0]);
+
+                /* This will succeed, since iov is set. */
+                assert_se(send_one_fd_iov(pair[1], -1, &iov, 1, MSG_DONTWAIT) == 0);
+                _exit(EXIT_SUCCESS);
+        }
+
+        /* Parent */
+        char buf[64];
+        struct iovec iov = IOVEC_INIT(buf, sizeof(buf)-1);
+        int fd = -999;
+        ssize_t k;
+
+        pair[1] = safe_close(pair[1]);
+
+        k = receive_one_fd_iov(pair[0], &iov, 1, MSG_DONTWAIT, &fd);
+        /* receive_one_fd_iov() returns -EIO if an fd is not found and no data was returned. */
+        assert_se(k == -EIO);
+
+        /* receive_one_fd_iov returned error, so confirm &fd wasn't touched */
+        assert_se(fd == -999);
 }
 
 int main(int argc, char *argv[]) {
@@ -514,6 +723,12 @@ int main(int argc, char *argv[]) {
         test_in_addr_is_multicast();
 
         test_getpeercred_getpeergroups();
+
+        test_passfd_read();
+        test_passfd_contents_read();
+        test_receive_nopassfd();
+        test_send_nodata_nofd();
+        test_send_emptydata();
 
         return 0;
 }


### PR DESCRIPTION
Let's enable Address Sanitizer and Undefined Behavior Sanitizer for RHEL 8. This should be much easier than the RHEL 7 effort, as the necessary patches to make it work should be relatively *fresh*.

Also, I'll try to hunt down all fixes which have been already introduced in upstream to weed out all known issues.

One side note (mainly for @msekletar) - I finally found out why neither `~/.bash_profile` nor `~/.bashrc` was working in Docker. I'll just copy-paste my note from the source:

```
# Note to my future frustrated self: docker exec runs the given command
# as sh -c 'command' - which means both .bash_profile and .bashrc will
# be ignored. That's because .bash_profile is sourced for LOGIN shells (i.e.
# sh -l), whereas .bashrc is sourced for NON-LOGIN INTERACTIVE shells
# (i.e. sh -i).
# As the default docker exec command lacks either of those options,
# we need to use a wrapper command which runs the wanted command
# under an explicit bash -i, so the SCL source above works properly.
``` 