### PR TITLE
(#1670126) rules: add the rule that adds elevator= kernel command line parameter

### DIFF
--- a/rules/meson.build
+++ b/rules/meson.build
@@ -2,6 +2,7 @@
 
 rules = files('''
         40-redhat.rules
+        40-elevator.rules
         60-block.rules
         60-cdrom_id.rules
         60-drm.rules


### PR DESCRIPTION
rhel-only
Resolves: #1670126