### PR TITLE
test: don't overwrite TESTDIR if already set

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -711,8 +711,13 @@ inst_libs() {
 
 import_testdir() {
     [[ -e $STATEFILE ]] && . $STATEFILE
-    if [[ -z "$TESTDIR" ]] || [[ ! -d "$TESTDIR" ]]; then
-        TESTDIR=$(mktemp --tmpdir=/var/tmp -d -t systemd-test.XXXXXX)
+    if [[ ! -d "$TESTDIR" ]]; then
+        if [[ -z "$TESTDIR" ]]; then
+            TESTDIR=$(mktemp --tmpdir=/var/tmp -d -t systemd-test.XXXXXX)
+        else
+            mkdir -p "$TESTDIR"
+        fi
+
         echo "TESTDIR=\"$TESTDIR\"" > $STATEFILE
         export TESTDIR
     fi


### PR DESCRIPTION
(cherry picked from commit 3f50fff536d715aee5e5195ec60e2af047b73c7f)

This fixes artifact collection after recent parallelization changes in CentOS CI, see https://github.com/systemd/systemd/pull/11981.