### PR TITLE
(#1691511) Backport core: Fix edge case when processing /proc/self/mountinfo

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1527,7 +1527,7 @@ static int mount_setup_unit(
 
         if (set_flags) {
                 MOUNT(u)->is_mounted = true;
-                MOUNT(u)->just_mounted = !MOUNT(u)->from_proc_self_mountinfo;
+                MOUNT(u)->just_mounted = !MOUNT(u)->from_proc_self_mountinfo || MOUNT(u)->just_mounted;
                 MOUNT(u)->just_changed = changed;
         }
 


### PR DESCRIPTION
Currently, if there are two /proc/self/mountinfo entries with the same
mount point path, the mount setup flags computed for the second of
these two entries will overwrite the mount setup flags computed for
the first of these two entries. This is the root cause of issue #7798.
This patch changes mount_setup_existing_unit to prevent the
just_mounted mount setup flag from being overwritten if it is set to
true. This will allow all mount units created from /proc/self/mountinfo
entries to be initialized properly.

(cherry picked from commit 65d36b49508a53e56bae9609ff00fdc3de340608)

Changed the downstream implementation as upstream has refactored quite a bit.

Resolves: #1691511